### PR TITLE
Feat/commit reveal unit test

### DIFF
--- a/commit-reveal2/commit_test.go
+++ b/commit-reveal2/commit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -919,6 +920,581 @@ func TestGenerateCommitIntegration(t *testing.T) {
 		assert.NotEqual(t, [32]byte{}, secretValue1)
 		assert.NotEqual(t, [32]byte{}, cos1)
 		assert.NotEqual(t, [32]byte{}, cvs1)
+	})
+}
+
+func TestGenerateCommit_TimestampNonDeterminism(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	mockService := &MockEthServiceForGenerateCommit{
+		activatedOperators: []common.Address{
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		},
+	}
+	eth.Service = mockService
+
+	round := "1"
+	operator := "0x1234567890123456789012345678901234567890"
+	results := make(map[string]bool)
+	uniqueCount := 0
+
+	for i := 0; i < 10; i++ {
+		secretValue, cos, cvs, err := GenerateCommit(round, operator)
+		assert.NoError(t, err)
+		secretHex := hex.EncodeToString(secretValue[:])
+		cosHex := hex.EncodeToString(cos[:])
+		cvsHex := hex.EncodeToString(cvs[:])
+		key := secretHex + cosHex + cvsHex
+		if !results[key] {
+			uniqueCount++
+			results[key] = true
+		}
+
+		assert.NotEqual(t, [32]byte{}, secretValue)
+		assert.NotEqual(t, [32]byte{}, cos)
+		assert.NotEqual(t, [32]byte{}, cvs)
+	}
+	t.Logf("Generated %d unique commit combinations out of 10 attempts", uniqueCount)
+}
+
+func TestGenerateCommit_OperatorIndexOverflow(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	operators := make([]common.Address, 260)
+	for i := 0; i < 260; i++ {
+		addrBytes := make([]byte, 20)
+		addrBytes[19] = byte(i)
+		addrBytes[18] = byte(i >> 8)
+		operators[i] = common.BytesToAddress(addrBytes)
+	}
+
+	mockService := &MockEthServiceForGenerateCommit{
+		activatedOperators: operators,
+	}
+	eth.Service = mockService
+
+	round := "1"
+
+	operator0 := operators[0].Hex()
+	secretValue0, cos0, cvs0, err0 := GenerateCommit(round, operator0)
+	assert.NoError(t, err0)
+	assert.NotEqual(t, [32]byte{}, secretValue0)
+	assert.NotEqual(t, [32]byte{}, cos0)
+	assert.NotEqual(t, [32]byte{}, cvs0)
+
+	operator255 := operators[255].Hex()
+	secretValue255, cos255, cvs255, err255 := GenerateCommit(round, operator255)
+	assert.NoError(t, err255)
+	assert.NotEqual(t, [32]byte{}, secretValue255)
+	assert.NotEqual(t, [32]byte{}, cos255)
+	assert.NotEqual(t, [32]byte{}, cvs255)
+
+	operator256 := operators[256].Hex()
+	secretValue256, cos256, cvs256, err256 := GenerateCommit(round, operator256)
+	assert.NoError(t, err256)
+	assert.NotEqual(t, [32]byte{}, secretValue256)
+	assert.NotEqual(t, [32]byte{}, cos256)
+	assert.NotEqual(t, [32]byte{}, cvs256)
+
+	assert.NotEqual(t, cvs0, cvs256, "Index 256 wraps to 0, but CVS differs due to different COS")
+
+	operator259 := operators[259].Hex()
+	secretValue259, cos259, cvs259, err259 := GenerateCommit(round, operator259)
+	assert.NoError(t, err259)
+	assert.NotEqual(t, [32]byte{}, secretValue259)
+	assert.NotEqual(t, [32]byte{}, cos259)
+	assert.NotEqual(t, [32]byte{}, cvs259)
+
+	operator3 := operators[3].Hex()
+	_, _, cvs3, _ := GenerateCommit(round, operator3)
+	assert.NotEqual(t, cvs3, cvs259, "Index 259 wraps to 3, but CVS differs due to different COS")
+
+	index256Int := 256
+	index259Int := 259
+	index256 := uint8(index256Int)
+	index259 := uint8(index259Int)
+	assert.Equal(t, uint8(0), index256, "uint8(256) should wrap to 0")
+	assert.Equal(t, uint8(3), index259, "uint8(259) should wrap to 3")
+}
+
+func TestGenerateCommit_TimestampEdgeCases(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	mockService := &MockEthServiceForGenerateCommit{
+		activatedOperators: []common.Address{
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		},
+	}
+	eth.Service = mockService
+
+	operator := "0x1234567890123456789012345678901234567890"
+
+	t.Run("zero round with timestamp", func(t *testing.T) {
+		round := "0"
+		secretValue, cos, cvs, err := GenerateCommit(round, operator)
+		assert.NoError(t, err)
+		assert.NotEqual(t, [32]byte{}, secretValue)
+		assert.NotEqual(t, [32]byte{}, cos)
+		assert.NotEqual(t, [32]byte{}, cvs)
+	})
+
+	t.Run("very large round number", func(t *testing.T) {
+		round := "999999999999999999999999999999999999999999999"
+		secretValue, cos, cvs, err := GenerateCommit(round, operator)
+		assert.NoError(t, err)
+		assert.NotEqual(t, [32]byte{}, secretValue)
+		assert.NotEqual(t, [32]byte{}, cos)
+		assert.NotEqual(t, [32]byte{}, cvs)
+	})
+
+	t.Run("timestamp with different rounds", func(t *testing.T) {
+		operator := "0x1234567890123456789012345678901234567890"
+
+		secret1, _, _, err1 := GenerateCommit("100", operator)
+		assert.NoError(t, err1)
+
+		secret2, _, _, err2 := GenerateCommit("200", operator)
+		assert.NoError(t, err2)
+
+		assert.NotEqual(t, secret1, secret2)
+	})
+}
+
+func TestGenerateCommit_AddressMatchingEdgeCases(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	round := "1"
+
+	t.Run("case sensitive address matching", func(t *testing.T) {
+		operatorAddr := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+		operators := []common.Address{
+			operatorAddr,
+		}
+		mockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: operators,
+		}
+		eth.Service = mockService
+
+		operatorLower := operatorAddr.Hex()
+		_, _, _, err := GenerateCommit(round, operatorLower)
+		assert.NoError(t, err, "Lowercase address should match")
+
+		operatorUpper := "0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+		_, _, _, err2 := GenerateCommit(round, operatorUpper)
+		assert.Error(t, err2, "Uppercase address should fail due to case-sensitive string comparison")
+		assert.Contains(t, err2.Error(), "not found in activated operators")
+	})
+
+	t.Run("zero address handling", func(t *testing.T) {
+		zeroAddr := common.Address{}
+		operators := []common.Address{
+			zeroAddr,
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		}
+		mockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: operators,
+		}
+		eth.Service = mockService
+
+		secretValue, cos, cvs, err := GenerateCommit(round, zeroAddr.Hex())
+		assert.NoError(t, err)
+		assert.NotEqual(t, [32]byte{}, secretValue)
+		assert.NotEqual(t, [32]byte{}, cos)
+		assert.NotEqual(t, [32]byte{}, cvs)
+	})
+
+	t.Run("duplicate operators in list", func(t *testing.T) {
+		operator := common.HexToAddress("0x1111111111111111111111111111111111111111")
+		// Create list with duplicate operator
+		operators := []common.Address{
+			operator,
+			common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			operator, // Duplicate
+		}
+		mockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: operators,
+		}
+		eth.Service = mockService
+
+		secretValue1, cos1, cvs1, err1 := GenerateCommit(round, operator.Hex())
+		assert.NoError(t, err1)
+
+		assert.NotEqual(t, [32]byte{}, secretValue1)
+		assert.NotEqual(t, [32]byte{}, cos1)
+		assert.NotEqual(t, [32]byte{}, cvs1)
+	})
+
+	t.Run("invalid address format", func(t *testing.T) {
+		operators := []common.Address{
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		}
+		mockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: operators,
+		}
+		eth.Service = mockService
+
+		invalidAddresses := []string{
+			"0x123",
+			"1234567890123456789012345678901234567890",
+			"0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+		}
+
+		for _, invalidAddr := range invalidAddresses {
+			_, _, _, err := GenerateCommit(round, invalidAddr)
+
+			assert.Error(t, err, "Invalid address %s should return error", invalidAddr)
+			assert.Contains(t, err.Error(), "not found in activated operators",
+				"Error should indicate operator not found for address: %s", invalidAddr)
+		}
+	})
+}
+
+func TestGenerateCommit_CryptographicProperties(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	mockService := &MockEthServiceForGenerateCommit{
+		activatedOperators: []common.Address{
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		},
+	}
+	eth.Service = mockService
+
+	operator := "0x1234567890123456789012345678901234567890"
+
+	t.Run("collision resistance - different inputs produce different outputs", func(t *testing.T) {
+		secretResults := make(map[string]bool)
+		cosResults := make(map[string]bool)
+		cvsResults := make(map[string]bool)
+
+		for i := 0; i < 100; i++ {
+			round := fmt.Sprintf("%d", i)
+			secretValue, cos, cvs, err := GenerateCommit(round, operator)
+			assert.NoError(t, err)
+
+			secretHex := hex.EncodeToString(secretValue[:])
+			cosHex := hex.EncodeToString(cos[:])
+			cvsHex := hex.EncodeToString(cvs[:])
+
+			if secretResults[secretHex] {
+				t.Logf("Secret value collision detected at round %s - this is expected if called in same second", round)
+			}
+			secretResults[secretHex] = true
+
+			if cosResults[cosHex] {
+				t.Logf("COS collision detected at round %s - this is expected if called in same second", round)
+			}
+			cosResults[cosHex] = true
+
+			if cvsResults[cvsHex] {
+				t.Logf("CVS collision detected at round %s - this is expected if called in same second", round)
+			}
+			cvsResults[cvsHex] = true
+
+			assert.NotEqual(t, secretValue, cos, "SecretValue should not equal COS")
+			assert.NotEqual(t, cos, cvs, "COS should not equal CVS")
+			assert.NotEqual(t, secretValue, cvs, "SecretValue should not equal CVS")
+		}
+
+		uniqueSecrets := len(secretResults)
+		t.Logf("Generated %d unique secrets out of 100 attempts (allowing for timestamp collisions)", uniqueSecrets)
+		assert.Greater(t, uniqueSecrets, 90, "Should have high uniqueness with different rounds")
+	})
+
+	t.Run("entropy quality - secret values are well distributed", func(t *testing.T) {
+		round := "1"
+		secretValues := make([][32]byte, 50)
+
+		for i := 0; i < 50; i++ {
+			secretValue, _, _, err := GenerateCommit(round, operator)
+			assert.NoError(t, err)
+			secretValues[i] = secretValue
+		}
+
+		zeroCount := 0
+		uniqueSecrets := make(map[string]bool)
+		for _, sv := range secretValues {
+			if sv == [32]byte{} {
+				zeroCount++
+			}
+			uniqueSecrets[hex.EncodeToString(sv[:])] = true
+		}
+
+		assert.Equal(t, 0, zeroCount, "No secret values should be zero")
+		t.Logf("Generated %d unique secrets out of 50 attempts", len(uniqueSecrets))
+	})
+
+	t.Run("preimage resistance - cannot derive inputs from outputs", func(t *testing.T) {
+		round := "42"
+		secretValue, cos, cvs, err := GenerateCommit(round, operator)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, [32]byte{}, secretValue)
+		assert.NotEqual(t, [32]byte{}, cos)
+		assert.NotEqual(t, [32]byte{}, cvs)
+
+		expectedCos := Keccak256(AbiEncode(secretValue[:]))
+		assert.Equal(t, expectedCos, cos[:], "COS should be hash of secretValue")
+	})
+
+	t.Run("uniqueness - same inputs in different seconds produce different secrets", func(t *testing.T) {
+		round := "100"
+		operator := "0x1234567890123456789012345678901234567890"
+
+		secretValue1, cos1, cvs1, err1 := GenerateCommit(round, operator)
+		assert.NoError(t, err1)
+
+		secretValue2, cos2, cvs2, err2 := GenerateCommit(round, operator)
+		assert.NoError(t, err2)
+
+		if secretValue1 == secretValue2 {
+			t.Log("Same secret generated - likely same timestamp second")
+		} else {
+			assert.NotEqual(t, secretValue1, secretValue2, "Different timestamps should produce different secrets")
+			assert.NotEqual(t, cos1, cos2)
+			assert.NotEqual(t, cvs1, cvs2)
+		}
+	})
+
+	t.Run("hash with zero inputs", func(t *testing.T) {
+		zeroOperator := common.Address{}.Hex()
+		zeroOperators := []common.Address{
+			common.Address{},
+		}
+		zeroMockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: zeroOperators,
+		}
+		eth.Service = zeroMockService
+
+		secretValue, cos, cvs, err := GenerateCommit("0", zeroOperator)
+		assert.NoError(t, err)
+
+		assert.Len(t, secretValue, 32, "Secret value should be 32 bytes even with zero inputs")
+		assert.Len(t, cos, 32, "COS should be 32 bytes")
+		assert.Len(t, cvs, 32, "CVS should be 32 bytes")
+
+		assert.NotEqual(t, [32]byte{}, secretValue, "Hash of zero inputs should not be all zeros")
+		assert.NotEqual(t, [32]byte{}, cos, "COS should not be all zeros")
+		assert.NotEqual(t, [32]byte{}, cvs, "CVS should not be all zeros")
+	})
+
+	t.Run("hash with maximum values", func(t *testing.T) {
+		eth.Service = mockService
+
+		maxRound := "9223372036854775807" 
+		veryLargeRound := "999999999999999999999999999999999999999999999999999999999999999999999"
+
+		secretValue1, cos1, cvs1, err1 := GenerateCommit(maxRound, operator)
+		assert.NoError(t, err1)
+
+		secretValue2, cos2, cvs2, err2 := GenerateCommit(veryLargeRound, operator)
+		assert.NoError(t, err2)
+
+	
+		assert.Len(t, secretValue1, 32)
+		assert.Len(t, cos1, 32)
+		assert.Len(t, cvs1, 32)
+		assert.Len(t, secretValue2, 32)
+		assert.Len(t, cos2, 32)
+		assert.Len(t, cvs2, 32)
+
+		assert.NotEqual(t, secretValue1, secretValue2, "Different large rounds should produce different secrets")
+	})
+
+	t.Run("hash output format - always 32 bytes", func(t *testing.T) {
+		eth.Service = mockService
+
+		testRounds := []string{"1", "10", "100", "1000", "999999"}
+
+		for _, testRound := range testRounds {
+			secretValue, cos, cvs, err := GenerateCommit(testRound, operator)
+			assert.NoError(t, err)
+
+
+			assert.Len(t, secretValue, 32, "Secret value must be exactly 32 bytes for round %s", testRound)
+			assert.Len(t, cos, 32, "COS must be exactly 32 bytes for round %s", testRound)
+			assert.Len(t, cvs, 32, "CVS must be exactly 32 bytes for round %s", testRound)
+
+			assert.NotEqual(t, [32]byte{}, secretValue, "Secret value should not be zero for round %s", testRound)
+			assert.NotEqual(t, [32]byte{}, cos, "COS should not be zero for round %s", testRound)
+			assert.NotEqual(t, [32]byte{}, cvs, "CVS should not be zero for round %s", testRound)
+		}
+	})
+
+	t.Run("hash avalanche effect - small input change produces completely different output", func(t *testing.T) {
+		eth.Service = mockService
+
+		round1 := "100"
+		round2 := "101" 
+
+		secretValue1, cos1, cvs1, err1 := GenerateCommit(round1, operator)
+		assert.NoError(t, err1)
+
+		secretValue2, cos2, cvs2, err2 := GenerateCommit(round2, operator)
+		assert.NoError(t, err2)
+		assert.NotEqual(t, secretValue1, secretValue2, "Small round change should produce different secrets")
+		assert.NotEqual(t, cos1, cos2, "Small round change should produce different COS")
+		assert.NotEqual(t, cvs1, cvs2, "Small round change should produce different CVS")
+
+		bitDiff := 0
+		for i := 0; i < 32; i++ {
+			xor := secretValue1[i] ^ secretValue2[i]
+			for xor != 0 {
+				bitDiff++
+				xor &= xor - 1
+			}
+		}
+		assert.Greater(t, bitDiff, 64, "Avalanche effect: at least 25%% of bits should differ, got %d/256", bitDiff)
+		t.Logf("Bit difference between secrets: %d/256 bits (%.1f%%)", bitDiff, float64(bitDiff)/256*100)
+	})
+
+	t.Run("hash with special byte patterns", func(t *testing.T) {
+		allZerosAddr := common.Address{} 
+		allFFAddr := common.BytesToAddress([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+		// Alternating pattern
+		altBytes := make([]byte, 20)
+		for i := range altBytes {
+			if i%2 == 0 {
+				altBytes[i] = 0xAA
+			} else {
+				altBytes[i] = 0x55
+			}
+		}
+		altPatternAddr := common.BytesToAddress(altBytes)
+
+		specialOperators := []common.Address{
+			allZerosAddr,
+			allFFAddr,
+			altPatternAddr,
+		}
+		specialMockService := &MockEthServiceForGenerateCommit{
+			activatedOperators: specialOperators,
+		}
+		eth.Service = specialMockService
+
+
+		results := make(map[string][32]byte)
+		for i, op := range specialOperators {
+			secretValue, cos, cvs, err := GenerateCommit("42", op.Hex())
+			assert.NoError(t, err, "Should handle special pattern operator at index %d", i)
+
+		
+			assert.Len(t, secretValue, 32)
+			assert.Len(t, secretValue, 32)
+			assert.Len(t, cos, 32)
+			assert.Len(t, cvs, 32)
+			assert.NotEqual(t, [32]byte{}, secretValue)
+			assert.NotEqual(t, [32]byte{}, cos)
+			assert.NotEqual(t, [32]byte{}, cvs)
+
+			secretHex := hex.EncodeToString(secretValue[:])
+			results[secretHex] = secretValue
+		}
+
+		assert.Equal(t, 3, len(results), "All special pattern operators should produce unique secrets")
+	})
+}
+
+func TestGenerateCommit_InputValidation(t *testing.T) {
+	originalService := eth.Service
+	defer func() {
+		eth.Service = originalService
+	}()
+
+	mockService := &MockEthServiceForGenerateCommit{
+		activatedOperators: []common.Address{
+			common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		},
+	}
+	eth.Service = mockService
+
+	operator := "0x1234567890123456789012345678901234567890"
+
+	t.Run("empty round string", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("", operator)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid round")
+	})
+
+	t.Run("whitespace-only round", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("   ", operator)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid round")
+	})
+
+	t.Run("round with leading zeros", func(t *testing.T) {
+		secretValue, cos, cvs, err := GenerateCommit("0001", operator)
+		if err == nil {
+			assert.NotEqual(t, [32]byte{}, secretValue)
+			assert.NotEqual(t, [32]byte{}, cos)
+			assert.NotEqual(t, [32]byte{}, cvs)
+		}
+	})
+
+	t.Run("round with special characters", func(t *testing.T) {
+		invalidRounds := []string{
+			"abc",
+			"1.5",
+			"0x123",
+			"1e10",
+			"-1",
+			"1+1",
+		}
+
+		for _, invalidRound := range invalidRounds {
+			_, _, _, err := GenerateCommit(invalidRound, operator)
+			if err != nil {
+				assert.Contains(t, err.Error(), "invalid round")
+			}
+		}
+	})
+
+	t.Run("empty operator string", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("1", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in activated operators")
+	})
+
+	t.Run("operator with whitespace", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("1", " 0x1234567890123456789012345678901234567890 ")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in activated operators")
+	})
+
+	t.Run("very long round string", func(t *testing.T) {
+
+		longRound := "1" + fmt.Sprintf("%0*d", 1000, 0)
+		_, _, _, err := GenerateCommit(longRound, operator)
+		if err != nil {
+			assert.Contains(t, err.Error(), "invalid round")
+		}
+	})
+
+	t.Run("round with newline characters", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("1\n", operator)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid round")
+	})
+
+	t.Run("round with tab characters", func(t *testing.T) {
+		_, _, _, err := GenerateCommit("1\t", operator)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid round")
 	})
 }
 

--- a/commit-reveal2/merkleTree_test.go
+++ b/commit-reveal2/merkleTree_test.go
@@ -99,9 +99,10 @@ func TestCreateMerkleTree(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, root, 32)
 
-		// For 3 leaves, we can't predict the exact algorithm without understanding the implementation
-		// Let's just verify that we get a valid 32-byte root that's not all zeros
-		assert.NotEqual(t, make([]byte, 32), root)
+
+		hash0 := efficientKeccak256(leaf1, leaf2)
+		expectedRoot := efficientKeccak256(leaf3, hash0)
+		assert.Equal(t, expectedRoot, root)
 	})
 
 	t.Run("four leaves", func(t *testing.T) {
@@ -205,6 +206,16 @@ func TestCreateMerkleTree(t *testing.T) {
 		// All roots should be identical
 		assert.Equal(t, root1, root2)
 		assert.Equal(t, root2, root3)
+
+		paddedLeaf1 := make([]byte, 32)
+		copy(paddedLeaf1, leaf1)
+		paddedLeaf2 := make([]byte, 32)
+		copy(paddedLeaf2, leaf2)
+		paddedLeaf3 := make([]byte, 32)
+		copy(paddedLeaf3, leaf3)
+		hash0 := efficientKeccak256(paddedLeaf1, paddedLeaf2)
+		expectedRoot := efficientKeccak256(paddedLeaf3, hash0)
+		assert.Equal(t, expectedRoot, root1)
 	})
 
 	t.Run("order matters", func(t *testing.T) {
@@ -233,9 +244,14 @@ func TestCreateMerkleTree(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, root, 32)
 
-		// Verify it's not a zero hash
-		zeroHash := make([]byte, 32)
-		assert.NotEqual(t, zeroHash, root)
+		hash0 := efficientKeccak256(leaves[0], leaves[1])
+		hash1 := efficientKeccak256(leaves[2], leaves[3])
+		hash2 := efficientKeccak256(leaves[4], leaves[5])
+		hash3 := efficientKeccak256(leaves[6], leaves[7])
+		hash4 := efficientKeccak256(hash0, hash1)
+		hash5 := efficientKeccak256(hash2, hash3)
+		expectedRoot := efficientKeccak256(hash4, hash5)
+		assert.Equal(t, expectedRoot, root)
 	})
 
 	t.Run("empty bytes in leaves", func(t *testing.T) {
@@ -258,34 +274,112 @@ func TestCreateMerkleTreeEdgeCases(t *testing.T) {
 	t.Run("leaves with all same values", func(t *testing.T) {
 		sameValue := make([]byte, 32)
 		sameValue[31] = 0x42
-		
+
 		leaves := [][]byte{
 			sameValue,
 			sameValue,
 			sameValue,
 			sameValue,
 		}
-		
+
 		root, err := CreateMerkleTree(leaves)
 		assert.NoError(t, err)
 		assert.Len(t, root, 32)
 		assert.NotEqual(t, make([]byte, 32), root)
+
+		hash1 := efficientKeccak256(leaves[0], leaves[1])
+		hash2 := efficientKeccak256(leaves[2], leaves[3])
+		expectedRoot := efficientKeccak256(hash1, hash2)
+		assert.Equal(t, expectedRoot, root)
 	})
 
 	t.Run("many leaves", func(t *testing.T) {
 		numLeaves := 16
 		leaves := make([][]byte, numLeaves)
-		
+
 		for i := 0; i < numLeaves; i++ {
 			leaf := make([]byte, 32)
 			leaf[31] = byte(i)
 			leaves[i] = leaf
 		}
-		
+
 		root, err := CreateMerkleTree(leaves)
 		assert.NoError(t, err)
 		assert.Len(t, root, 32)
 		assert.NotEqual(t, make([]byte, 32), root)
+
+		hash0 := efficientKeccak256(leaves[0], leaves[1])
+		hash1 := efficientKeccak256(leaves[2], leaves[3])
+		hash2 := efficientKeccak256(leaves[4], leaves[5])
+		hash3 := efficientKeccak256(leaves[6], leaves[7])
+		hash4 := efficientKeccak256(leaves[8], leaves[9])
+		hash5 := efficientKeccak256(leaves[10], leaves[11])
+		hash6 := efficientKeccak256(leaves[12], leaves[13])
+		hash7 := efficientKeccak256(leaves[14], leaves[15])
+
+		hash8 := efficientKeccak256(hash0, hash1)
+		hash9 := efficientKeccak256(hash2, hash3)
+		hash10 := efficientKeccak256(hash4, hash5)
+		hash11 := efficientKeccak256(hash6, hash7)
+	
+		hash12 := efficientKeccak256(hash8, hash9)
+		hash13 := efficientKeccak256(hash10, hash11)
+		// Level 4: Final root
+		expectedRoot := efficientKeccak256(hash12, hash13)
+		assert.Equal(t, expectedRoot, root)
+	})
+
+	t.Run("thirty-two leaves", func(t *testing.T) {
+		numLeaves := 32
+		leaves := make([][]byte, numLeaves)
+
+		for i := 0; i < numLeaves; i++ {
+			leaf := make([]byte, 32)
+			leaf[31] = byte(i)
+			leaves[i] = leaf
+		}
+
+		root, err := CreateMerkleTree(leaves)
+		require.NoError(t, err)
+		assert.Len(t, root, 32)
+		assert.NotEqual(t, make([]byte, 32), root)
+
+		h0 := efficientKeccak256(leaves[0], leaves[1])
+		h1 := efficientKeccak256(leaves[2], leaves[3])
+		h2 := efficientKeccak256(leaves[4], leaves[5])
+		h3 := efficientKeccak256(leaves[6], leaves[7])
+		h4 := efficientKeccak256(leaves[8], leaves[9])
+		h5 := efficientKeccak256(leaves[10], leaves[11])
+		h6 := efficientKeccak256(leaves[12], leaves[13])
+		h7 := efficientKeccak256(leaves[14], leaves[15])
+		h8 := efficientKeccak256(leaves[16], leaves[17])
+		h9 := efficientKeccak256(leaves[18], leaves[19])
+		h10 := efficientKeccak256(leaves[20], leaves[21])
+		h11 := efficientKeccak256(leaves[22], leaves[23])
+		h12 := efficientKeccak256(leaves[24], leaves[25])
+		h13 := efficientKeccak256(leaves[26], leaves[27])
+		h14 := efficientKeccak256(leaves[28], leaves[29])
+		h15 := efficientKeccak256(leaves[30], leaves[31])
+		// Level 2: Pair level 1 hashes (8 hashes)
+		h16 := efficientKeccak256(h0, h1)
+		h17 := efficientKeccak256(h2, h3)
+		h18 := efficientKeccak256(h4, h5)
+		h19 := efficientKeccak256(h6, h7)
+		h20 := efficientKeccak256(h8, h9)
+		h21 := efficientKeccak256(h10, h11)
+		h22 := efficientKeccak256(h12, h13)
+		h23 := efficientKeccak256(h14, h15)
+		// Level 3: Pair level 2 hashes (4 hashes)
+		h24 := efficientKeccak256(h16, h17)
+		h25 := efficientKeccak256(h18, h19)
+		h26 := efficientKeccak256(h20, h21)
+		h27 := efficientKeccak256(h22, h23)
+		// Level 4: Pair level 3 hashes (2 hashes)
+		h28 := efficientKeccak256(h24, h25)
+		h29 := efficientKeccak256(h26, h27)
+		// Level 5: Final root
+		expectedRoot := efficientKeccak256(h28, h29)
+		assert.Equal(t, expectedRoot, root)
 	})
 
 	t.Run("leaves with nil bytes", func(t *testing.T) {
@@ -295,7 +389,7 @@ func TestCreateMerkleTreeEdgeCases(t *testing.T) {
 			nil,
 			{0x02},
 		}
-		
+
 		root, err := CreateMerkleTree(leaves)
 		assert.NoError(t, err)
 		assert.Len(t, root, 32)
@@ -304,16 +398,16 @@ func TestCreateMerkleTreeEdgeCases(t *testing.T) {
 	t.Run("extremely long leaves", func(t *testing.T) {
 		longLeaf1 := make([]byte, 1000)
 		longLeaf2 := make([]byte, 500)
-		
+
 		for i := range longLeaf1 {
 			longLeaf1[i] = 0xAA
 		}
 		for i := range longLeaf2 {
 			longLeaf2[i] = 0xBB
 		}
-		
+
 		leaves := [][]byte{longLeaf1, longLeaf2}
-		
+
 		root, err := CreateMerkleTree(leaves)
 		assert.NoError(t, err)
 		assert.Len(t, root, 32)

--- a/nodes/leader/accept_commit.go
+++ b/nodes/leader/accept_commit.go
@@ -1181,16 +1181,21 @@ func (n *LeaderNode) GenerateMerkleRoot(ctx context.Context, roundNum string, tr
 		log.Println("System is halted. Skipping GenerateMerkleRoot.")
 		return
 	}
-	n.commitMu.Lock()
-	// Check if merkle root is a-lready done before proceeding
-	uniqueKey := utils.GetUniqueKey(roundNum, trialNum)
 
-	// Check if merkle root is already submitted using atomic operation
-	if n.GetSubmittingMerkleRoot() {
-		log.Printf("Merkle root is already being submitted for round %s with trail %s, skipping.", roundNum, trialNum)
-		n.commitMu.Unlock()
+	if !n.CompareAndSwapSubmittingMerkleRoot(false, true) {
+		log.Printf("Merkle root generation already in progress for round %s with trail %s, skipping.", roundNum, trialNum)
 		return
 	}
+
+	shouldResetFlag := true
+	defer func() {
+		if shouldResetFlag {
+			n.SetSubmittingMerkleRoot(false)
+		}
+	}()
+
+	n.commitMu.Lock()
+	uniqueKey := utils.GetUniqueKey(roundNum, trialNum)
 
 	// Check if already done via round data
 	roundData, exists := n.GetRoundData(uniqueKey)
@@ -1241,10 +1246,9 @@ func (n *LeaderNode) GenerateMerkleRoot(ctx context.Context, roundNum string, tr
 		log.Printf("Failed to create Merkle tree for round %s with trail %s: %v", roundNum, trialNum, err)
 		return
 	}
-	// Use atomic compare-and-swap to prevent race condition
-	if n.CompareAndSwapSubmittingMerkleRoot(false, true) {
-		n.SubmitMerkleRoot(ctx, roundNum, trialNum, merkleRoot)
-	}
+
+	shouldResetFlag = false
+	n.SubmitMerkleRoot(ctx, roundNum, trialNum, merkleRoot)
 }
 
 // SubmitMerkleRoot submits the merkle root to the blockchain

--- a/nodes/leader/accept_commit_test.go
+++ b/nodes/leader/accept_commit_test.go
@@ -2,9 +2,15 @@ package leader_node
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
+	"log"
 	"math/big"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,12 +19,17 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/go-pg/pg/v10"
+	_ "github.com/lib/pq"
 	"github.com/libp2p/go-libp2p"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/tokamak-network/DRB-node/database"
 	"github.com/tokamak-network/DRB-node/eth"
 	"github.com/tokamak-network/DRB-node/libp2putils"
 	"github.com/tokamak-network/DRB-node/pkg/fallback_ethclient"
@@ -200,6 +211,22 @@ func (m *MockEthServiceForAcceptCommit) GetTrialNumFromContract(ctx context.Cont
 	return nil, nil
 }
 
+func createMockHostForBroadcast() host.Host {
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream := new(MockStreamForBroadcast)
+
+	// Mock peerstore that accepts any address
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+	mockHost.On("Peerstore").Return(mockPeerstore)
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil)
+	mockStream.On("Write", mock.Anything).Return(100, nil)
+	mockStream.On("Close").Return(nil)
+
+	return mockHost
+}
+
 func createTestNodeForAcceptCommit() *LeaderNode {
 	node := createTestNodeForBroadcast()
 	mockLeaderCommitRepo := new(MockLeaderCommitRepository)
@@ -308,6 +335,7 @@ func TestProcessCOS_Success(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
 	assert.NoError(t, err)
@@ -377,6 +405,7 @@ func TestProcessCVS_Success(t *testing.T) {
 		Return(existingCommit, nil)
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
 	assert.NoError(t, err)
@@ -431,6 +460,9 @@ func TestProcessRequestedToSubmitCo_Success(t *testing.T) {
 	node.processRequestedToSubmitCo(context.Background(), blockTimestamp, round, trialNum)
 
 	assert.True(t, node.GetRequestedToSubmitCoMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCoMonitoring()
 }
 
 // TestProcessRequestedToSubmitCv_Success tests successful processing
@@ -444,6 +476,9 @@ func TestProcessRequestedToSubmitCv_Success(t *testing.T) {
 	node.processRequestedToSubmitCv(context.Background(), blockTimestamp, round, trialNum)
 
 	assert.True(t, node.GetRequestedToSubmitCvMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCvMonitoring()
 }
 
 // TestStartFailToSubmitCoMonitoring_NilTimestamp tests with nil timestamp
@@ -540,6 +575,9 @@ func TestProcessRequestedToSubmitCv_StopsExistingMonitoring(t *testing.T) {
 	node.processRequestedToSubmitCv(context.Background(), blockTimestamp, round, trialNum)
 
 	assert.True(t, node.GetRequestedToSubmitCvMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCvMonitoring()
 }
 
 // TestUpdateCommitDataAfterSubmit tests commit data update
@@ -644,6 +682,7 @@ func TestProcessCOS_UpdateExisting(t *testing.T) {
 		Return(existingCommit, nil)
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
 	assert.NoError(t, err)
@@ -676,6 +715,7 @@ func TestProcessCVS_UpdateExisting(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
 	assert.NoError(t, err)
@@ -708,6 +748,7 @@ func TestProcessCOS_AddCommitError(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("db error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
 	assert.Error(t, err)
@@ -750,6 +791,7 @@ func TestProcessCOS_UpdateError(t *testing.T) {
 		Return(existingCommit, nil)
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("update error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(ctx, round, trialNum, cos, index)
 	assert.Error(t, err)
@@ -784,6 +826,7 @@ func TestProcessCVS_AddCommitError(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("db error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
 	assert.Error(t, err)
@@ -823,6 +866,7 @@ func TestProcessCVS_UpdateError(t *testing.T) {
 		Return(existingCommit, nil)
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("update error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
 	assert.Error(t, err)
@@ -987,6 +1031,7 @@ func TestProcessSubmittedSecretRequest_Success(t *testing.T) {
 	node.broadcastTrackerRepository = mockBroadcastRepo
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	node.processSubmittedSecretRequest(context.Background(), round, trialNum, secret, index)
 
@@ -1051,6 +1096,7 @@ func TestProcessSubmittedSecretRequest_UpdateError(t *testing.T) {
 	mockBroadcastRepo := new(MockBroadcastTrackerRepository)
 	node.broadcastTrackerRepository = mockBroadcastRepo
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	node.processSubmittedSecretRequest(context.Background(), round, trialNum, secret, index)
@@ -1408,6 +1454,7 @@ func TestProcessSubmittedSecretRequest_WithMockEthService(t *testing.T) {
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	node.processSubmittedSecretRequest(context.Background(), round, trialNum, secret, index)
 
@@ -1441,6 +1488,7 @@ func TestProcessCOS_WithMockEthService(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
 	assert.NoError(t, err)
@@ -1475,6 +1523,7 @@ func TestProcessCVS_WithMockEthService(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
 	assert.NoError(t, err)
@@ -1857,6 +1906,9 @@ func TestProcessRequestedToSubmitCo_NotHalted(t *testing.T) {
 	node.processRequestedToSubmitCo(context.Background(), blockTimestamp, round, trialNum)
 
 	assert.True(t, node.GetRequestedToSubmitCoMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCoMonitoring()
 }
 
 // TestProcessRequestedToSubmitCv_NotHalted tests processing event
@@ -1870,6 +1922,9 @@ func TestProcessRequestedToSubmitCv_NotHalted(t *testing.T) {
 	node.processRequestedToSubmitCv(context.Background(), blockTimestamp, round, trialNum)
 
 	assert.True(t, node.GetRequestedToSubmitCvMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCvMonitoring()
 }
 
 // TestStartFailToSubmitCoMonitoring_ValidTimestamp tests normal monitoring start
@@ -2002,6 +2057,9 @@ func TestProcessRandomRequestNumber_StateOne(t *testing.T) {
 	assert.True(t, node.GetExecution())
 	assert.False(t, node.GetHalted())
 
+	// Clean up timer to prevent it from firing after test completes
+	node.stopRequestToSubmitCvMonitoring()
+
 	mockBatchRepo.AssertExpectations(t)
 }
 
@@ -2116,6 +2174,7 @@ func TestProcessCOS_StoresDataCorrectly(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
 	assert.NoError(t, err)
@@ -2156,6 +2215,7 @@ func TestProcessCVS_AllCvsReceivedTrigger(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// This should trigger GenerateMerkleRoot since all CVS received (only 1 operator)
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
@@ -2474,6 +2534,9 @@ func TestProcessRandomRequestNumber_StateOneWithDeleteError(t *testing.T) {
 
 	// Should still set execution even with delete error
 	assert.True(t, node.GetExecution())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopRequestToSubmitCvMonitoring()
 
 	mockBatchRepo.AssertExpectations(t)
 }
@@ -2999,6 +3062,7 @@ func TestProcessCOS_CheckStopMonitoring(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Process COS for first operator - should NOT stop monitoring since not all COS received
 	err := node.processCOS(context.Background(), round, trialNum, cos, index)
@@ -3044,6 +3108,7 @@ func TestProcessCVS_CheckStopMonitoring(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Process CVS for first operator - should NOT stop monitoring since not all CVS received
 	err := node.processCVS(context.Background(), round, trialNum, cvs, index)
@@ -3325,6 +3390,7 @@ func TestLeaderNode_receiveCommit_CvSubmitted_Success(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -3397,6 +3463,7 @@ func TestLeaderNode_receiveCommit_CoSubmitted_Success(t *testing.T) {
 		Return(nil, errors.New("not found"))
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -3597,6 +3664,9 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCo_Success(t *testing.T) {
 	// Verify monitoring was started
 	assert.True(t, node.GetRequestedToSubmitCoMonitoringActive())
 
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCoMonitoring()
+
 	mockClient.AssertExpectations(t)
 }
 
@@ -3655,6 +3725,9 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCv_Success(t *testing.T) {
 
 	// Verify monitoring was started
 	assert.True(t, node.GetRequestedToSubmitCvMonitoringActive())
+
+	// Clean up timer to prevent it from firing after test completes
+	node.stopFailToSubmitCvMonitoring()
 
 	mockClient.AssertExpectations(t)
 }
@@ -4327,7 +4400,6 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_NoConnection(t *testing
 	require.NoError(t, err)
 	defer testHost.Close()
 
-
 	peerHost, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 	defer peerHost.Close()
@@ -4373,7 +4445,6 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_InvalidPeerID(t *testin
 
 	mockEth := &MockEthServiceForAcceptCommit{
 		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
-			// No-op
 		},
 	}
 
@@ -4399,12 +4470,11 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_InvalidPeerID(t *testin
 	mockNodeRepo.AssertExpectations(t)
 }
 
-
 func TestLeaderNode_processDeactivated_ConnectionCleanup_NilP2PClient(t *testing.T) {
 	node := createTestNodeForAcceptCommit()
 	mockNodeRepo := new(MockNodeInfoRepositoryForAcceptCommit)
 	node.nodeInfoRepository = mockNodeRepo
-	node.p2pClient = nil 
+	node.p2pClient = nil
 
 	testOp := common.HexToAddress("0x6666666666666666666666666666666666666666")
 
@@ -4433,8 +4503,6 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_NilHostInstance(t *test
 	node := createTestNodeForAcceptCommit()
 	mockNodeRepo := new(MockNodeInfoRepositoryForAcceptCommit)
 	node.nodeInfoRepository = mockNodeRepo
-
-	// Don't set host - HostInstance will be nil
 	testOp := common.HexToAddress("0x7777777777777777777777777777777777777777")
 
 	mockEth := &MockEthServiceForAcceptCommit{
@@ -5026,6 +5094,7 @@ func TestLeaderNode_receiveCommit_SSubmitted_Success(t *testing.T) {
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
@@ -5154,6 +5223,7 @@ func TestLeaderNode_receiveCommit_SSubmitted_BlockTimestampError(t *testing.T) {
 		Return(existingCommit, nil)
 	mockLeaderRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -6363,4 +6433,886 @@ func TestLeaderNode_resuming_CallSmartContractError(t *testing.T) {
 
 	// Should handle error gracefully
 	assert.True(t, true)
+}
+
+type ConcurrentMockLeaderCommitRepository struct {
+	mock.Mock
+	mu              sync.Mutex
+	commits         map[string]*utils.LeaderCommitData
+	addCallCount    int
+	updateCallCount int
+}
+
+func NewConcurrentMockLeaderCommitRepository() *ConcurrentMockLeaderCommitRepository {
+	return &ConcurrentMockLeaderCommitRepository{
+		commits: make(map[string]*utils.LeaderCommitData),
+	}
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) GetLeaderCommitByRoundAndEoaAddr(ctx context.Context, round, trialNum, eoaAddr string) (*utils.LeaderCommitData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := round + "-" + trialNum + "-" + eoaAddr
+	if commit, exists := m.commits[key]; exists {
+		return commit, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) UpdateLeaderCommit(ctx context.Context, commitData *utils.LeaderCommitData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := commitData.Round + "-" + commitData.TrialNum + "-" + commitData.EOAAddress
+	m.commits[key] = commitData
+	m.updateCallCount++
+	return nil
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) AddLeaderCommit(ctx context.Context, commitData *utils.LeaderCommitData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := commitData.Round + "-" + commitData.TrialNum + "-" + commitData.EOAAddress
+	if _, exists := m.commits[key]; exists {
+		return errors.New("duplicate key")
+	}
+	m.commits[key] = commitData
+	m.addCallCount++
+	return nil
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) GetAllLeaderCommits(ctx context.Context) ([]*utils.LeaderCommitData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]*utils.LeaderCommitData, 0, len(m.commits))
+	for _, commit := range m.commits {
+		result = append(result, commit)
+	}
+	return result, nil
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) GetLeaderCommitsByRoundAndTrialNum(ctx context.Context, round, trialNum string) ([]*utils.LeaderCommitData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]*utils.LeaderCommitData, 0)
+	for _, commit := range m.commits {
+		if commit.Round == round && commit.TrialNum == trialNum {
+			result = append(result, commit)
+		}
+	}
+	return result, nil
+}
+
+func (m *ConcurrentMockLeaderCommitRepository) UpdateLeaderCommitRandomNumberGenerated(ctx context.Context, round, trialNum string) error {
+	return nil
+}
+
+func TestProcessCVS_ConcurrentSameOperator(t *testing.T) {
+	node := createTestNodeForAcceptCommit()
+	mockRepo := NewConcurrentMockLeaderCommitRepository()
+	node.leaderCommitRepository = mockRepo
+	mockBroadcastRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockBroadcastRepo
+
+	activatedOps := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	round := big.NewInt(5000)
+	trialNum := big.NewInt(1)
+	var cvs1, cvs2 [32]byte
+	copy(cvs1[:], []byte("cvs-concurrent-1"))
+	copy(cvs2[:], []byte("cvs-concurrent-2"))
+	index := big.NewInt(0)
+
+	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	errors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if idx%2 == 0 {
+				errors[idx] = node.processCVS(context.Background(), round, trialNum, cvs1, index)
+			} else {
+				errors[idx] = node.processCVS(context.Background(), round, trialNum, cvs2, index)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	errorCount := 0
+	for _, err := range errors {
+		if err != nil {
+			errorCount++
+		}
+	}
+
+	t.Logf("Error count: %d out of %d goroutines", errorCount, numGoroutines)
+	fmt.Printf("Error count: %d out of %d goroutines\n", errorCount, numGoroutines)
+
+	assert.LessOrEqual(t, errorCount, numGoroutines-1, "At least one operation should succeed")
+
+	commit, err := mockRepo.GetLeaderCommitByRoundAndEoaAddr(context.Background(), round.String(), trialNum.String(), activatedOps[0].Hex())
+	assert.NoError(t, err)
+	assert.NotNil(t, commit)
+	assert.Equal(t, round.String(), commit.Round)
+	assert.Equal(t, trialNum.String(), commit.TrialNum)
+}
+
+func TestProcessCVS_ConcurrentDifferentOperators(t *testing.T) {
+	// Setup real database connection
+	const (
+		postgresHost     = "localhost"
+		postgresUser     = "postgres"
+		postgresPassword = "123"
+		postgresDB       = "testdb"
+		postgresPort     = "5433"
+	)
+
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		postgresUser, postgresPassword, postgresHost, postgresPort, postgresDB)
+
+	sqlDB, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skipf("Skipping test: PostgreSQL database not available: %v", err)
+		return
+	}
+	defer sqlDB.Close()
+
+	err = sqlDB.Ping()
+	if err != nil {
+		t.Skipf("Skipping test: PostgreSQL database not available: %v", err)
+		return
+	}
+
+	// Run migrations
+	err = database.MigrationsUp(sqlDB)
+	require.NoError(t, err, "Failed to run migrations")
+
+	// Connect using go-pg
+	testDB := pg.Connect(&pg.Options{
+		Addr:     fmt.Sprintf("%s:%s", postgresHost, postgresPort),
+		User:     postgresUser,
+		Password: postgresPassword,
+		Database: postgresDB,
+	})
+
+	err = testDB.Ping(context.Background())
+	require.NoError(t, err, "Failed to connect to test database")
+
+	// Create real database repositories
+	realRepo := database.NewLeaderCommitRepository(testDB)
+	realBroadcastRepo := database.NewBroadcastTrackerRepository(testDB)
+
+	// Setup test node
+	node := createTestNodeForAcceptCommit()
+	node.leaderCommitRepository = realRepo
+	node.broadcastTrackerRepository = realBroadcastRepo
+
+	activatedOps := make([]common.Address, 32)
+	for i := 0; i < 32; i++ {
+		addrBytes := make([]byte, 20)
+		addrBytes[0] = byte(i + 1)
+		addrBytes[1] = byte(i + 1)
+		addrBytes[2] = byte(i + 1)
+		for j := 3; j < 20; j++ {
+			addrBytes[j] = byte(i + j)
+		}
+		activatedOps[i] = common.BytesToAddress(addrBytes)
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	// Register all operators in nodeInfo to avoid log warnings
+	mockNodeInfoRepo := new(MockNodeInfoRepository)
+	nodeInfos := make([]*utils.NodeInfo, len(activatedOps))
+	for i, op := range activatedOps {
+		// Generate valid PeerID for each operator
+		privKey, _, err := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+		var peerIDStr string
+		if err == nil {
+			peerID, err := peer.IDFromPrivateKey(privKey)
+			if err == nil {
+				peerIDStr = peerID.String()
+			} else {
+				// Fallback to a simple format if generation fails
+				peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+			}
+		} else {
+			// Fallback to a simple format if generation fails
+			peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+		}
+
+		nodeInfos[i] = &utils.NodeInfo{
+			EOAAddress: op.Hex(),
+			IP:         fmt.Sprintf("192.168.1.%d", i+1),
+			Port:       fmt.Sprintf("400%d", i+1),
+			PeerID:     peerIDStr,
+		}
+	}
+	// Setup mock to return nodeInfos for all GetNodeInfos calls (unlimited calls)
+	mockNodeInfoRepo.On("GetNodeInfos", mock.Anything).Return(nodeInfos, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeInfoRepo)
+
+	round := big.NewInt(5001)
+	trialNum := big.NewInt(1)
+	roundStr := round.String()
+	trialNumStr := trialNum.String()
+
+	// Create a cancellable context for the test operations
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	// Cleanup test data before test
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, op := range activatedOps {
+		testDB.Model(&database.LeaderCommitScheme{}).
+			Where("round = ? AND trial_num = ? AND eoa_address = ?", roundStr, trialNumStr, op.Hex()).
+			Context(ctx).
+			Delete()
+	}
+
+	// Cleanup test data after test
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+
+		for _, op := range activatedOps {
+			testDB.Model(&database.LeaderCommitScheme{}).
+				Where("round = ? AND trial_num = ? AND eoa_address = ?", roundStr, trialNumStr, op.Hex()).
+				Context(cleanupCtx).
+				Delete()
+		}
+		testDB.Close()
+	}()
+
+	// Mock ethService to handle GenerateMerkleRoot submission
+	mockEth := &MockEthServiceForAcceptCommit{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return activatedOps
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			// Mock successful submission
+			return nil, nil, nil
+		},
+	}
+	node.ethService = mockEth
+
+	// Use mock host to prevent actual network operations and avoid "context canceled" errors
+	if node.p2pClient != nil && node.p2pClient.GetHostInstance() == nil {
+		mockHost := createMockHostForBroadcast()
+		node.p2pClient.SetHost(mockHost)
+	}
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("LEADER_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("LEADER_PRIVATE_KEY")
+	}()
+
+	var wg sync.WaitGroup
+	errors := make([]error, len(activatedOps))
+
+	for i, op := range activatedOps {
+		wg.Add(1)
+		go func(idx int, operator common.Address) {
+			defer wg.Done()
+			var cvs [32]byte
+			copy(cvs[:], []byte{byte(idx), byte(idx + 1), byte(idx + 2)})
+			errors[idx] = node.processCVS(testCtx, round, trialNum, cvs, big.NewInt(int64(idx)))
+		}(i, op)
+	}
+
+	wg.Wait()
+
+	// Give broadcast goroutines some time to finish or be cancelled
+	time.Sleep(2 * time.Second)
+
+	// Cancel context to stop all broadcast goroutines
+	testCancel()
+
+	// Wait a bit more for goroutines to clean up
+	time.Sleep(1 * time.Second)
+
+	for i, err := range errors {
+		assert.NoError(t, err, "Operator %d should process successfully", i)
+	}
+
+	// Verify data in real database
+	for i, op := range activatedOps {
+		commit, err := realRepo.GetLeaderCommitByRoundAndEoaAddr(ctx, roundStr, trialNumStr, op.Hex())
+		assert.NoError(t, err, "Operator %d should have commit stored", i)
+		assert.NotNil(t, commit)
+		assert.Equal(t, roundStr, commit.Round)
+		assert.Equal(t, trialNumStr, commit.TrialNum)
+		assert.NotEqual(t, [32]byte{}, commit.Cvs, "CVS should be stored")
+	}
+}
+
+func TestProcessCOS_ConcurrentSubmissions(t *testing.T) {
+	// Setup real database connection
+	const (
+		postgresHost     = "localhost"
+		postgresUser     = "postgres"
+		postgresPassword = "123"
+		postgresDB       = "testdb"
+		postgresPort     = "5433"
+	)
+
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		postgresUser, postgresPassword, postgresHost, postgresPort, postgresDB)
+
+	sqlDB, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skipf("Skipping test: PostgreSQL database not available: %v", err)
+		return
+	}
+	defer sqlDB.Close()
+
+	err = sqlDB.Ping()
+	if err != nil {
+		t.Skipf("Skipping test: PostgreSQL database not available: %v", err)
+		return
+	}
+
+	// Run migrations
+	err = database.MigrationsUp(sqlDB)
+	require.NoError(t, err, "Failed to run migrations")
+
+	// Connect using go-pg
+	testDB := pg.Connect(&pg.Options{
+		Addr:     fmt.Sprintf("%s:%s", postgresHost, postgresPort),
+		User:     postgresUser,
+		Password: postgresPassword,
+		Database: postgresDB,
+	})
+
+	err = testDB.Ping(context.Background())
+	require.NoError(t, err, "Failed to connect to test database")
+
+	// Create real database repositories
+	realRepo := database.NewLeaderCommitRepository(testDB)
+	realBroadcastRepo := database.NewBroadcastTrackerRepository(testDB)
+
+	// Setup test node
+	node := createTestNodeForAcceptCommit()
+	node.leaderCommitRepository = realRepo
+	node.broadcastTrackerRepository = realBroadcastRepo
+
+	activatedOps := make([]common.Address, 32)
+	for i := 0; i < 32; i++ {
+		addrBytes := make([]byte, 20)
+		addrBytes[0] = byte(i + 1)
+		addrBytes[1] = byte(i + 1)
+		addrBytes[2] = byte(i + 1)
+		for j := 3; j < 20; j++ {
+			addrBytes[j] = byte(i + j)
+		}
+		activatedOps[i] = common.BytesToAddress(addrBytes)
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	// Register all operators in nodeInfo to avoid log warnings
+	mockNodeInfoRepo := new(MockNodeInfoRepository)
+	nodeInfos := make([]*utils.NodeInfo, len(activatedOps))
+	for i, op := range activatedOps {
+		// Generate valid PeerID for each operator
+		privKey, _, err := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+		var peerIDStr string
+		if err == nil {
+			peerID, err := peer.IDFromPrivateKey(privKey)
+			if err == nil {
+				peerIDStr = peerID.String()
+			} else {
+				// Fallback to a simple format if generation fails
+				peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+			}
+		} else {
+			// Fallback to a simple format if generation fails
+			peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+		}
+
+		nodeInfos[i] = &utils.NodeInfo{
+			EOAAddress: op.Hex(),
+			IP:         fmt.Sprintf("192.168.1.%d", i+1),
+			Port:       fmt.Sprintf("400%d", i+1),
+			PeerID:     peerIDStr,
+		}
+	}
+	// Setup mock to return nodeInfos for all GetNodeInfos calls (unlimited calls)
+	mockNodeInfoRepo.On("GetNodeInfos", mock.Anything).Return(nodeInfos, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeInfoRepo)
+
+	round := big.NewInt(5002)
+	trialNum := big.NewInt(1)
+	roundStr := round.String()
+	trialNumStr := trialNum.String()
+
+	// Create a cancellable context for the test operations
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	// Cleanup test data before test
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, op := range activatedOps {
+		testDB.Model(&database.LeaderCommitScheme{}).
+			Where("round = ? AND trial_num = ? AND eoa_address = ?", roundStr, trialNumStr, op.Hex()).
+			Context(ctx).
+			Delete()
+	}
+
+	// Cleanup test data after test
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+
+		for _, op := range activatedOps {
+			testDB.Model(&database.LeaderCommitScheme{}).
+				Where("round = ? AND trial_num = ? AND eoa_address = ?", roundStr, trialNumStr, op.Hex()).
+				Context(cleanupCtx).
+				Delete()
+		}
+		testDB.Close()
+	}()
+
+	mockRevealOrderService := new(MockRevealOrderService)
+	mockRevealOrderService.On("DetermineRevealOrder", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, errors.New("test error")).Maybe()
+	node.revealOrderService = mockRevealOrderService
+
+	// Use mock host to prevent actual network operations and avoid "context canceled" errors
+	if node.p2pClient != nil && node.p2pClient.GetHostInstance() == nil {
+		mockHost := createMockHostForBroadcast()
+		node.p2pClient.SetHost(mockHost)
+	}
+
+	// Run concurrent processCOS calls
+	var wg sync.WaitGroup
+	errors := make([]error, len(activatedOps))
+
+	for i, op := range activatedOps {
+		wg.Add(1)
+		go func(idx int, operator common.Address) {
+			defer wg.Done()
+			var cos [32]byte
+			copy(cos[:], []byte{byte(idx + 10), byte(idx + 11), byte(idx + 12)})
+			errors[idx] = node.processCOS(testCtx, round, trialNum, cos, big.NewInt(int64(idx)))
+		}(i, op)
+	}
+
+	wg.Wait()
+
+	// Give broadcast goroutines some time to finish or be cancelled
+	time.Sleep(2 * time.Second)
+
+	// Cancel context to stop all broadcast goroutines
+	testCancel()
+
+	// Wait a bit more for goroutines to clean up
+	time.Sleep(1 * time.Second)
+
+	// All operations should succeed
+	for i, err := range errors {
+		assert.NoError(t, err, "Operator %d should process COS successfully", i)
+	}
+
+	// Verify data in memory
+	uniqueKey := utils.GetUniqueKey(roundStr, trialNumStr)
+	for i, op := range activatedOps {
+		commitData, exists := utils.GetCommittedNodeData(uniqueKey, op)
+		assert.True(t, exists, "Operator %d should have commit data in memory", i)
+		assert.NotEqual(t, [32]byte{}, commitData.Cos, "COS should be stored in memory for operator %d", i)
+	}
+
+	// Verify data in real database
+	for i, op := range activatedOps {
+		commit, err := realRepo.GetLeaderCommitByRoundAndEoaAddr(context.Background(), roundStr, trialNumStr, op.Hex())
+		assert.NoError(t, err, "Operator %d should have commit stored in database", i)
+		assert.NotNil(t, commit)
+		assert.Equal(t, roundStr, commit.Round)
+		assert.Equal(t, trialNumStr, commit.TrialNum)
+		assert.NotEqual(t, [32]byte{}, commit.Cos, "COS should be stored in database for operator %d", i)
+	}
+}
+
+// TestProcessCVS_RaceConditionAllCvsReceived tests race condition where multiple goroutines check AllCvsReceivedUnlocked simultaneously
+func TestProcessCVS_RaceConditionAllCvsReceived(t *testing.T) {
+	node := createTestNodeForAcceptCommit()
+	mockRepo := NewConcurrentMockLeaderCommitRepository()
+	node.leaderCommitRepository = mockRepo
+	mockBroadcastRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockBroadcastRepo
+
+	activatedOps := []common.Address{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	round := big.NewInt(5003)
+	trialNum := big.NewInt(1)
+	uniqueKey := utils.GetUniqueKey(round.String(), trialNum.String())
+
+	// Create a cancellable context for the test operations
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	mockEth := &MockEthServiceForAcceptCommit{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return activatedOps
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			return nil, nil, nil
+		},
+	}
+	node.ethService = mockEth
+
+	// Use mock host to prevent actual network operations and avoid "context canceled" errors
+	if node.p2pClient != nil && node.p2pClient.GetHostInstance() == nil {
+		mockHost := createMockHostForBroadcast()
+		node.p2pClient.SetHost(mockHost)
+	}
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("LEADER_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("LEADER_PRIVATE_KEY")
+	}()
+
+	var wg sync.WaitGroup
+	for i, op := range activatedOps {
+		wg.Add(1)
+		go func(idx int, operator common.Address) {
+			defer wg.Done()
+			var cvs [32]byte
+			copy(cvs[:], []byte{byte(idx), byte(idx + 1)})
+			_ = node.processCVS(testCtx, round, trialNum, cvs, big.NewInt(int64(idx)))
+		}(i, op)
+	}
+
+	wg.Wait()
+
+	// Give broadcast goroutines some time to finish or be cancelled
+	time.Sleep(2 * time.Second)
+
+	// Cancel context to stop all broadcast goroutines
+	testCancel()
+
+	// Wait a bit more for goroutines to clean up
+	time.Sleep(1 * time.Second)
+
+	time.Sleep(100 * time.Millisecond)
+
+	for _, op := range activatedOps {
+		commit, err := mockRepo.GetLeaderCommitByRoundAndEoaAddr(context.Background(), round.String(), trialNum.String(), op.Hex())
+		assert.NoError(t, err)
+		assert.NotNil(t, commit)
+		assert.NotEqual(t, [32]byte{}, commit.Cvs)
+	}
+
+	assert.True(t, node.AllCvsReceivedUnlocked(uniqueKey), "All CVS should be received")
+}
+
+func TestProcessCVS_RaceConditionAllCvsReceived_WithTracking(t *testing.T) {
+	node := createTestNodeForAcceptCommit()
+	mockRepo := NewConcurrentMockLeaderCommitRepository()
+	node.leaderCommitRepository = mockRepo
+	mockBroadcastRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockBroadcastRepo
+
+	activatedOps := make([]common.Address, 32)
+	for i := 0; i < 32; i++ {
+		addrBytes := make([]byte, 20)
+		addrBytes[0] = byte(i + 1)
+		addrBytes[1] = byte(i + 1)
+		addrBytes[2] = byte(i + 1)
+		for j := 3; j < 20; j++ {
+			addrBytes[j] = byte(i + j)
+		}
+		activatedOps[i] = common.BytesToAddress(addrBytes)
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	// Register all operators in nodeInfo to avoid log warnings
+	mockNodeInfoRepo := new(MockNodeInfoRepository)
+	nodeInfos := make([]*utils.NodeInfo, len(activatedOps))
+	for i, op := range activatedOps {
+		// Generate valid PeerID for each operator
+		privKey, _, err := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+		var peerIDStr string
+		if err == nil {
+			peerID, err := peer.IDFromPrivateKey(privKey)
+			if err == nil {
+				peerIDStr = peerID.String()
+			} else {
+				// Fallback to a simple format if generation fails
+				peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+			}
+		} else {
+			// Fallback to a simple format if generation fails
+			peerIDStr = fmt.Sprintf("12D3KooW%032d", i)
+		}
+
+		nodeInfos[i] = &utils.NodeInfo{
+			EOAAddress: op.Hex(),
+			IP:         fmt.Sprintf("192.168.1.%d", i+1),
+			Port:       fmt.Sprintf("400%d", i+1),
+			PeerID:     peerIDStr,
+		}
+	}
+
+	mockNodeInfoRepo.On("GetNodeInfos", mock.Anything).Return(nodeInfos, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeInfoRepo)
+
+	round := big.NewInt(5010)
+	trialNum := big.NewInt(1)
+	uniqueKey := utils.GetUniqueKey(round.String(), trialNum.String())
+
+	testCtx, testCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer testCancel()
+
+	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	var logOutput strings.Builder
+	originalLogWriter := log.Writer()
+	log.SetOutput(&logOutput)
+	defer func() {
+		log.SetOutput(originalLogWriter)
+	}()
+
+	submitMerkleRootCallCount := int32(0)
+
+	mockEth := &MockEthServiceForAcceptCommit{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return activatedOps
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitMerkleRoot" {
+				atomic.AddInt32(&submitMerkleRootCallCount, 1)
+			}
+			return nil, nil, nil
+		},
+	}
+	node.ethService = mockEth
+
+	if node.p2pClient != nil && node.p2pClient.GetHostInstance() == nil {
+		mockHost := createMockHostForBroadcast()
+		node.p2pClient.SetHost(mockHost)
+	}
+
+	// Set environment variables
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("LEADER_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("LEADER_PRIVATE_KEY")
+	}()
+
+	var wg sync.WaitGroup
+	for i, op := range activatedOps {
+		wg.Add(1)
+		go func(idx int, operator common.Address) {
+			defer wg.Done()
+			if idx < 2 {
+				time.Sleep(10 * time.Millisecond)
+			}
+			var cvs [32]byte
+			copy(cvs[:], []byte{byte(idx), byte(idx + 1), byte(idx + 2)})
+			_ = node.processCVS(testCtx, round, trialNum, cvs, big.NewInt(int64(idx)))
+		}(i, op)
+	}
+
+	wg.Wait()
+
+	// Give broadcast goroutines some time to finish or be cancelled
+	time.Sleep(2 * time.Second)
+
+	// Cancel context to stop all broadcast goroutines
+	testCancel()
+
+	// Wait a bit more for goroutines to clean up
+	time.Sleep(1 * time.Second)
+
+	time.Sleep(500 * time.Millisecond)
+
+	logStr := logOutput.String()
+	generateMerkleRootCallCount := strings.Count(logStr, "Generating Merkle root")
+
+	submitCount := atomic.LoadInt32(&submitMerkleRootCallCount)
+
+	assert.Equal(t, 1, generateMerkleRootCallCount,
+		"GenerateMerkleRoot should be called exactly once")
+
+	assert.Equal(t, int32(1), submitCount, "SubmitMerkleRoot should be called exactly once")
+
+	if generateMerkleRootCallCount == 1 {
+		t.Logf("Result: Only one goroutine can proceed, eliminating the race condition")
+	} else {
+		t.Errorf("RACE CONDITION EXISTS: GenerateMerkleRoot called %d times instead of 1", generateMerkleRootCallCount)
+	}
+
+	// Verify all CVS values were stored
+	for _, op := range activatedOps {
+		commit, err := mockRepo.GetLeaderCommitByRoundAndEoaAddr(context.Background(), round.String(), trialNum.String(), op.Hex())
+		assert.NoError(t, err)
+		assert.NotNil(t, commit)
+		assert.NotEqual(t, [32]byte{}, commit.Cvs)
+	}
+
+	assert.True(t, node.AllCvsReceivedUnlocked(uniqueKey), "All CVS should be received")
+
+	data, exists := node.GetRoundData(uniqueKey)
+	if exists {
+		assert.True(t, data.MerkleRoot, "Merkle root should be marked as submitted")
+	}
+}
+
+// TestGenerateMerkleRoot_ConcurrentCalls tests concurrent GenerateMerkleRoot calls
+func TestGenerateMerkleRoot_ConcurrentCalls(t *testing.T) {
+	node := createTestNodeForAcceptCommit()
+
+	// Use a mock repository that handles UpdateLeaderCommit
+	mockRepo := new(MockLeaderCommitRepository)
+	mockRepo.On("UpdateLeaderCommit", mock.Anything, mock.Anything).Return(nil).Maybe()
+	node.leaderCommitRepository = mockRepo
+
+	testOp1 := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	testOp2 := common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+
+	// Track submission calls by mocking the ethService ExecuteTransaction
+	submitCallCount := int32(0)
+	mockEth := &MockEthServiceForAcceptCommit{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{testOp1, testOp2}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitMerkleRoot" {
+				atomic.AddInt32(&submitCallCount, 1)
+			}
+			return nil, nil, nil
+		},
+	}
+	node.ethService = mockEth
+
+	// Set environment variables for merkle root submission
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("LEADER_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("LEADER_PRIVATE_KEY")
+	}()
+
+	round := "5004"
+	trialNum := "1"
+	uniqueKey := utils.GetUniqueKey(round, trialNum)
+
+	utils.SetCommittedNodeData(uniqueKey, testOp1, utils.LeaderCommitData{Cvs: [32]byte{1}})
+	utils.SetCommittedNodeData(uniqueKey, testOp2, utils.LeaderCommitData{Cvs: [32]byte{2}})
+
+	// Run concurrent GenerateMerkleRoot calls
+	var wg sync.WaitGroup
+	numGoroutines := 10
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			node.GenerateMerkleRoot(context.Background(), round, trialNum)
+		}()
+	}
+
+	wg.Wait()
+
+	// Wait a bit for any pending SubmitMerkleRoot calls
+	time.Sleep(200 * time.Millisecond)
+
+	callCount := atomic.LoadInt32(&submitCallCount)
+	assert.Equal(t, int32(1), callCount,
+		"SubmitMerkleRoot should be called exactly once")
+
+	data, exists := node.GetRoundData(uniqueKey)
+	if exists {
+		assert.True(t, data.MerkleRoot, "Merkle root should be marked as submitted")
+	}
+}
+
+// TestProcessCVS_ConcurrentDatabaseOperations tests concurrent database operations
+func TestProcessCVS_ConcurrentDatabaseOperations(t *testing.T) {
+	node := createTestNodeForAcceptCommit()
+	mockRepo := NewConcurrentMockLeaderCommitRepository()
+	node.leaderCommitRepository = mockRepo
+	mockBroadcastRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockBroadcastRepo
+
+	activatedOps := []common.Address{
+		common.HexToAddress("0x7777777777777777777777777777777777777777"),
+	}
+	eth.SetActivatedOperatorsCached(activatedOps)
+	defer eth.SetActivatedOperatorsCached([]common.Address{})
+
+	round := big.NewInt(5006)
+	trialNum := big.NewInt(1)
+
+	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// First, add a commit
+	var initialCvs [32]byte
+	copy(initialCvs[:], []byte("initial-cvs"))
+	err := node.processCVS(context.Background(), round, trialNum, initialCvs, big.NewInt(0))
+	assert.NoError(t, err)
+
+	// Now run concurrent updates
+	var wg sync.WaitGroup
+	numGoroutines := 5
+	errors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			var cvs [32]byte
+			copy(cvs[:], []byte{byte(idx), byte(idx + 1)})
+			errors[idx] = node.processCVS(context.Background(), round, trialNum, cvs, big.NewInt(0))
+		}(i)
+	}
+
+	wg.Wait()
+
+	successCount := 0
+	for _, err := range errors {
+		if err == nil {
+			successCount++
+		}
+	}
+	assert.Greater(t, successCount, 0, "At least one update should succeed")
+
+	commit, err := mockRepo.GetLeaderCommitByRoundAndEoaAddr(context.Background(), round.String(), trialNum.String(), activatedOps[0].Hex())
+	assert.NoError(t, err)
+	assert.NotNil(t, commit)
+	assert.NotEqual(t, [32]byte{}, commit.Cvs, "CVS should be stored")
 }

--- a/nodes/leader/broad_cast.go
+++ b/nodes/leader/broad_cast.go
@@ -206,15 +206,25 @@ func (n *LeaderNode) performReliableBroadcast(ctx context.Context, h host.Host, 
 		n.broadcastMutex.Unlock()
 
 		for _, op := range operatorsToSend {
-			// Add peer info into peer store
-			peerID := nodeInfo[op.Hex()].PeerID
-			peerAddrStr := fmt.Sprintf("/ip4/%s/tcp/%s", nodeInfo[op.Hex()].IP, nodeInfo[op.Hex()].Port)
-			peerAddr, _ := multiaddr.NewMultiaddr(peerAddrStr)
+			nodeInfoEntry, exists := nodeInfo[op.Hex()]
+			if !exists {
+				log.Printf("Operator %s is activated but not registered in nodeInfo", op.Hex())
+				continue
+			}
+
+			peerID := nodeInfoEntry.PeerID
+			peerAddrStr := fmt.Sprintf("/ip4/%s/tcp/%s", nodeInfoEntry.IP, nodeInfoEntry.Port)
+
+			peerAddr, err := multiaddr.NewMultiaddr(peerAddrStr)
+			if err != nil {
+				log.Printf("Failed to parse multiaddr for operator %s: %v. Skipping broadcast.", op.Hex(), err)
+				continue
+			}
 			h.Peerstore().AddAddr(peerID, peerAddr, peerstore.PermanentAddrTTL)
 
-			stream, err := h.NewStream(ctx, nodeInfo[op.Hex()].PeerID, streamProtocol)
+			stream, err := h.NewStream(ctx, nodeInfoEntry.PeerID, streamProtocol)
 			if err != nil {
-				log.Printf("Failed to create stream to peer %s: %v", nodeInfo[op.Hex()].PeerID, err)
+				log.Printf("Failed to create stream to peer %s: %v", nodeInfoEntry.PeerID, err)
 				continue
 			}
 			defer stream.Close()
@@ -333,15 +343,25 @@ func (n *LeaderNode) performReliableBroadcastSync(ctx context.Context, h host.Ho
 		n.broadcastMutex.Unlock()
 
 		for _, op := range operatorsToSend {
-			// Add peer info into peer store
-			peerID := nodeInfo[op.Hex()].PeerID
-			peerAddrStr := fmt.Sprintf("/ip4/%s/tcp/%s", nodeInfo[op.Hex()].IP, nodeInfo[op.Hex()].Port)
-			peerAddr, _ := multiaddr.NewMultiaddr(peerAddrStr)
+			nodeInfoEntry, exists := nodeInfo[op.Hex()]
+			if !exists {
+				log.Printf("Operator %s is activated but not registered in nodeInfo", op.Hex())
+				continue
+			}
+
+			peerID := nodeInfoEntry.PeerID
+			peerAddrStr := fmt.Sprintf("/ip4/%s/tcp/%s", nodeInfoEntry.IP, nodeInfoEntry.Port)
+
+			peerAddr, err := multiaddr.NewMultiaddr(peerAddrStr)
+			if err != nil {
+				log.Printf("Failed to parse multiaddr for operator %s: %v. Skipping broadcast.", op.Hex(), err)
+				continue
+			}
 			h.Peerstore().AddAddr(peerID, peerAddr, peerstore.PermanentAddrTTL)
 
-			stream, err := h.NewStream(ctx, nodeInfo[op.Hex()].PeerID, streamProtocol)
+			stream, err := h.NewStream(ctx, nodeInfoEntry.PeerID, streamProtocol)
 			if err != nil {
-				log.Printf("Failed to create stream to peer %s: %v", nodeInfo[op.Hex()].PeerID, err)
+				log.Printf("Failed to create stream to peer %s: %v", nodeInfoEntry.PeerID, err)
 				continue
 			}
 			defer stream.Close()
@@ -412,7 +432,6 @@ func (n *LeaderNode) HandleAcknowledgment(ctx context.Context, ack utils.Acknowl
 	}
 
 	if ack.Status == "received" {
-		// Mark acknowledgment from the sender (regular node that sent the ack)
 		tracker.Acknowledged[ack.EOAAddress] = true
 
 		// Check if all nodes have acknowledged

--- a/nodes/leader/broad_cast_test.go
+++ b/nodes/leader/broad_cast_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -1239,13 +1240,15 @@ func TestPerformReliableBroadcast_WithNetworkAttempt(t *testing.T) {
 
 	// Create operator addresses
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	// Create a mock node repo that returns specific node info
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID), // Convert peer.ID to string
+			PeerID:     peerID.String(), 
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1305,13 +1308,15 @@ func TestPerformReliableBroadcast_WithSuccessfulStream(t *testing.T) {
 
 	// Create operator addresses
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	// Create a mock node repo that returns specific node info
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID), // Convert peer.ID to string
+			PeerID:     peerID.String(), 
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1379,13 +1384,15 @@ func TestPerformReliableBroadcastSync_WithNetworkAttempt(t *testing.T) {
 
 	// Create operator addresses
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	// Create a mock node repo that returns specific node info
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID), // Convert peer.ID to string
+			PeerID:     peerID.String(), 
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1445,13 +1452,15 @@ func TestPerformReliableBroadcastSync_WithSuccessfulStream(t *testing.T) {
 
 	// Create operator addresses
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	// Create a mock node repo that returns specific node info
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID), // Convert peer.ID to string
+			PeerID:     peerID.String(), 
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1517,13 +1526,15 @@ func TestPerformReliableBroadcastSync_WithEncodingError(t *testing.T) {
 
 	// Create operator addresses
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	// Create a mock node repo that returns specific node info
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID),
+			PeerID:     peerID.String(),
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1588,12 +1599,14 @@ func TestPerformReliableBroadcast_SecretBroadcastType(t *testing.T) {
 	defer os.Unsetenv("LEADER_PRIVATE_KEY")
 
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID),
+			PeerID:     peerID.String(),
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1651,12 +1664,14 @@ func TestPerformReliableBroadcastSync_CvsBroadcastType(t *testing.T) {
 	defer os.Unsetenv("LEADER_PRIVATE_KEY")
 
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID),
+			PeerID:     peerID.String(),
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1712,12 +1727,14 @@ func TestPerformReliableBroadcastSync_CosBroadcastType(t *testing.T) {
 	defer os.Unsetenv("LEADER_PRIVATE_KEY")
 
 	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
-	peerID, _ := peer.Decode("QmTest123456789012345678901234567890123456789012")
+
+	privKey, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID, _ := peer.IDFromPrivateKey(privKey)
 
 	mockNodeRepo := new(MockNodeInfoRepository)
 	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
 		{
-			PeerID:     string(peerID),
+			PeerID:     peerID.String(),
 			IP:         "127.0.0.1",
 			Port:       "8080",
 			EOAAddress: opAddr1.Hex(),
@@ -1759,4 +1776,710 @@ func TestPerformReliableBroadcastSync_CosBroadcastType(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 	mockHost.AssertExpectations(t)
 	mockStream.AssertExpectations(t)
+}
+
+func TestPerformReliableBroadcast_MixedSuccessFailureInSingleAttempt(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+
+	opAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	opAddr3 := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey2, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey3, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+	peerID2, _ := peer.IDFromPrivateKey(privKey2)
+	peerID3, _ := peer.IDFromPrivateKey(privKey3)
+
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8081", EOAAddress: opAddr1.Hex()},
+		{PeerID: peerID2.String(), IP: "127.0.0.1", Port: "8082", EOAAddress: opAddr2.Hex()},
+		{PeerID: peerID3.String(), IP: "127.0.0.1", Port: "8083", EOAAddress: opAddr3.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream1 := new(MockStreamForBroadcast) 
+	mockStream3 := new(MockStreamForBroadcast) 
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()                      
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("connection refused")).Maybe() // Node 2 fail
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream3, nil).Maybe()                
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()                      // Node 2 retry
+
+	mockStream1.On("Write", mock.Anything).Return(100, nil)
+	mockStream1.On("Close").Return(nil)
+	mockStream3.On("Write", mock.Anything).Return(100, nil)
+	mockStream3.On("Close").Return(nil)
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-mixed-success-failure",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "cvs",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0, // No sleep for fast test
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+			opAddr2.Hex(): false, // This one will fail
+			opAddr3.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+
+	acknowledgeNodes := func() {
+		time.Sleep(10 * time.Millisecond)
+		tracker.Acknowledged[opAddr1.Hex()] = true
+		tracker.Acknowledged[opAddr3.Hex()] = true
+	}
+	go acknowledgeNodes()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "cvs", []common.Address{opAddr1, opAddr2, opAddr3})
+
+	assert.Equal(t, 2, tracker.Attempts)
+	
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+
+}
+
+func TestPerformReliableBroadcast_StreamClosesMidTransmission(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8080", EOAAddress: opAddr1.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil).Maybe()
+
+	mockStream.On("Write", mock.Anything).Return(50, nil).Maybe()
+	mockStream.On("Write", mock.Anything).Return(0, errors.New("stream closed")).Maybe()
+	mockStream.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-stream-closes-mid",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "secret",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0,
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+	// Second attempt should retry
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil).Maybe()
+	mockStream.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream.On("Close").Return(nil).Maybe()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "secret", []common.Address{opAddr1})
+
+	assert.Equal(t, 2, tracker.Attempts)
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+	mockHost.AssertExpectations(t)
+	mockStream.AssertExpectations(t)
+}
+
+func TestPerformReliableBroadcast_LateAcknowledgmentDuringRetry(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	opAddr2 := common.HexToAddress("0xAbC1234567890123456789012345678901234567")
+
+
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey2, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+	peerID2, _ := peer.IDFromPrivateKey(privKey2)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8081", EOAAddress: opAddr1.Hex()},
+		{PeerID: peerID2.String(), IP: "127.0.0.1", Port: "8082", EOAAddress: opAddr2.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream1 := new(MockStreamForBroadcast)
+	mockStream2 := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	// Both nodes succeed in first attempt
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream2, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+	mockStream2.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream2.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-late-ack",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "cos",
+		Attempts:    0,
+		MaxAttempts: 3,
+		Timeout:     10, 
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+			opAddr2.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+	go func() {
+		time.Sleep(15 * time.Millisecond) 
+		tracker.Acknowledged[opAddr1.Hex()] = true
+	}()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	node.performReliableBroadcast(ctx, mockHost, tracker, "cos", []common.Address{opAddr1, opAddr2})
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, tracker.Acknowledged[opAddr1.Hex()])
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestPerformReliableBroadcast_RaceConditionAcknowledgment(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	// Generate valid peer ID
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8080", EOAAddress: opAddr1.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	// First attempt succeeds
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil).Maybe()
+	mockStream.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-race-condition",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "cvs",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0, // No timeout for fast test
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		tracker.Acknowledged[opAddr1.Hex()] = true
+	}()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "cvs", []common.Address{opAddr1})
+
+	// Should break early if acknowledgment received
+	time.Sleep(20 * time.Millisecond)
+	assert.True(t, tracker.Acknowledged[opAddr1.Hex()])
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestPerformReliableBroadcast_MultipleNodesMixedNetworkConditions(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	// Create 4 operator addresses
+	opAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	opAddr3 := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	opAddr4 := common.HexToAddress("0x4444444444444444444444444444444444444444")
+
+	// Generate valid peer IDs
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey2, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey3, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey4, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+	peerID2, _ := peer.IDFromPrivateKey(privKey2)
+	peerID3, _ := peer.IDFromPrivateKey(privKey3)
+	peerID4, _ := peer.IDFromPrivateKey(privKey4)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8081", EOAAddress: opAddr1.Hex()},
+		{PeerID: peerID2.String(), IP: "127.0.0.1", Port: "8082", EOAAddress: opAddr2.Hex()},
+		{PeerID: peerID3.String(), IP: "127.0.0.1", Port: "8083", EOAAddress: opAddr3.Hex()},
+		{PeerID: peerID4.String(), IP: "127.0.0.1", Port: "8084", EOAAddress: opAddr4.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream1 := new(MockStreamForBroadcast) // Success
+	mockStream3 := new(MockStreamForBroadcast) // Success
+	mockStream4 := new(MockStreamForBroadcast) // Success
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("connection refused")).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream3, nil).Maybe()
+	mockStream3.On("Write", mock.Anything).Return(0, errors.New("write failed")).Maybe()
+	mockStream3.On("Close").Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream4, nil).Maybe()
+	mockStream4.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream4.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-mixed-network",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "secret",
+		Attempts:    0,
+		MaxAttempts: 3,
+		Timeout:     0,
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+			opAddr2.Hex(): false, 
+			opAddr3.Hex(): false, 
+			opAddr4.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		tracker.Acknowledged[opAddr1.Hex()] = true
+		tracker.Acknowledged[opAddr4.Hex()] = true
+	}()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+
+	
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream3, nil).Maybe()
+	mockStream3.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream3.On("Close").Return(nil).Maybe()
+
+	
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		tracker.Acknowledged[opAddr2.Hex()] = true
+		tracker.Acknowledged[opAddr3.Hex()] = true
+	}()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "secret", []common.Address{opAddr1, opAddr2, opAddr3, opAddr4})
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.GreaterOrEqual(t, tracker.Attempts, 2)               
+	assert.LessOrEqual(t, tracker.Attempts, tracker.MaxAttempts) 
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+}
+
+// TestPerformReliableBroadcast_PartialStreamWrite tests handling of partial stream writes
+func TestPerformReliableBroadcast_PartialStreamWrite(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	// Generate valid peer ID
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8080", EOAAddress: opAddr1.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil).Maybe()
+	
+	mockStream.On("Write", mock.Anything).Return(30, nil).Maybe()
+
+	mockStream.On("Write", mock.Anything).Return(0, errors.New("connection reset")).Maybe()
+	mockStream.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-partial-write",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "cvs",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0,
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+	
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream, nil).Maybe()
+	mockStream.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream.On("Close").Return(nil).Maybe()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "cvs", []common.Address{opAddr1})
+
+	assert.Equal(t, 2, tracker.Attempts)
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+	mockHost.AssertExpectations(t)
+	mockStream.AssertExpectations(t)
+}
+
+
+func TestPerformReliableBroadcastSync_MixedSuccessFailureInSingleAttempt(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	opAddr3 := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey2, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey3, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+	peerID2, _ := peer.IDFromPrivateKey(privKey2)
+	peerID3, _ := peer.IDFromPrivateKey(privKey3)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8081", EOAAddress: opAddr1.Hex()},
+		{PeerID: peerID2.String(), IP: "127.0.0.1", Port: "8082", EOAAddress: opAddr2.Hex()},
+		{PeerID: peerID3.String(), IP: "127.0.0.1", Port: "8083", EOAAddress: opAddr3.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream1 := new(MockStreamForBroadcast)
+	mockStream3 := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+	
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+
+	
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("connection refused")).Maybe()
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream3, nil).Maybe()
+	mockStream3.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream3.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-sync-mixed",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "secret",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0,
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+			opAddr2.Hex(): false,
+			opAddr3.Hex(): false,
+		},
+	}
+
+	
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		tracker.Acknowledged[opAddr1.Hex()] = true
+		tracker.Acknowledged[opAddr3.Hex()] = true
+	}()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+
+	result := node.performReliableBroadcastSync(context.Background(), mockHost, tracker, "secret", []common.Address{opAddr1, opAddr2, opAddr3})
+
+	time.Sleep(20 * time.Millisecond)
+
+	assert.Equal(t, 2, tracker.Attempts)
+	assert.False(t, result) 
+
+	mockRepo.AssertExpectations(t)
+	mockHost.AssertExpectations(t)
+}
+
+func TestHandleAcknowledgment_AfterPartialDeliveryFailure(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	messageID := "test-partial-delivery-ack"
+	opAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	tracker := &utils.BroadcastTracker{
+		MessageID: messageID,
+		Round:     "100",
+		TrialNum:  "1",
+		Type:      "cvs",
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false, 
+			opAddr2.Hex(): true,  
+		},
+	}
+	node.SetActiveBroadcast(messageID, tracker)
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil)
+
+
+	ack := utils.AcknowledgmentMessage{
+		MessageID:  messageID,
+		EOAAddress: opAddr1.Hex(),
+		Status:     "received",
+		Type:       "cvs",
+	}
+
+	node.HandleAcknowledgment(context.Background(), ack)
+
+	updatedTracker, _ := node.GetActiveBroadcast(messageID)
+	assert.True(t, updatedTracker.Acknowledged[opAddr1.Hex()])
+	assert.True(t, updatedTracker.Acknowledged[opAddr2.Hex()])
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestPerformReliableBroadcast_EncodingFailureAfterStreamCreation(t *testing.T) {
+	node := createTestNodeForBroadcast()
+	mockRepo := new(MockBroadcastTrackerRepository)
+	node.broadcastTrackerRepository = mockRepo
+
+	pk, _ := crypto.GenerateKey()
+	pkHex := hex.EncodeToString(crypto.FromECDSA(pk))
+	os.Setenv("LEADER_PRIVATE_KEY", pkHex)
+	defer os.Unsetenv("LEADER_PRIVATE_KEY")
+
+	opAddr1 := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	opAddr2 := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	// Generate valid peer IDs
+	privKey1, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	privKey2, _, _ := libp2pcrypto.GenerateKeyPair(libp2pcrypto.Ed25519, 256)
+	peerID1, _ := peer.IDFromPrivateKey(privKey1)
+	peerID2, _ := peer.IDFromPrivateKey(privKey2)
+
+	mockNodeRepo := new(MockNodeInfoRepository)
+	mockNodeRepo.On("GetNodeInfos", mock.Anything).Return([]*utils.NodeInfo{
+		{PeerID: peerID1.String(), IP: "127.0.0.1", Port: "8081", EOAAddress: opAddr1.Hex()},
+		{PeerID: peerID2.String(), IP: "127.0.0.1", Port: "8082", EOAAddress: opAddr2.Hex()},
+	}, nil)
+	node.p2pClient = libp2putils.NewP2PClient(mockNodeRepo)
+
+	mockHost := new(MockHost)
+	mockPeerstore := new(MockPeerstore)
+	mockStream1 := new(MockStreamForBroadcast)
+	mockStream2 := new(MockStreamForBroadcast)
+
+	mockHost.On("Peerstore").Return(mockPeerstore)
+	mockPeerstore.On("AddAddr", mock.Anything, mock.Anything, mock.Anything).Return()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream1, nil).Maybe()
+	mockStream1.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream1.On("Close").Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream2, nil).Maybe()
+	mockStream2.On("Write", mock.Anything).Return(0, errors.New("encoding error")).Maybe()
+	mockStream2.On("Close").Return(nil).Maybe()
+
+	tracker := &utils.BroadcastTracker{
+		MessageID:   "test-encoding-failure",
+		Round:       "100",
+		TrialNum:    "1",
+		EOAAddress:  opAddr1.Hex(),
+		Type:        "cos",
+		Attempts:    0,
+		MaxAttempts: 2,
+		Timeout:     0,
+		Acknowledged: map[string]bool{
+			opAddr1.Hex(): false,
+			opAddr2.Hex(): false,
+		},
+	}
+	node.SetActiveBroadcast(tracker.MessageID, tracker)
+
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		tracker.Acknowledged[opAddr1.Hex()] = true
+	}()
+
+	mockRepo.On("UpdateBroadcastTracker", mock.Anything, tracker).Return(nil).Maybe()
+
+
+	mockHost.On("NewStream", mock.Anything, mock.Anything, mock.Anything).Return(mockStream2, nil).Maybe()
+	mockStream2.On("Write", mock.Anything).Return(100, nil).Maybe()
+	mockStream2.On("Close").Return(nil).Maybe()
+
+	node.performReliableBroadcast(context.Background(), mockHost, tracker, "cos", []common.Address{opAddr1, opAddr2})
+
+	assert.Equal(t, 2, tracker.Attempts)
+	_, exists := node.GetActiveBroadcast(tracker.MessageID)
+	assert.False(t, exists)
+
+	mockRepo.AssertExpectations(t)
+
 }

--- a/nodes/regular/regular_node_test.go
+++ b/nodes/regular/regular_node_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	// "github.com/go-pg/pg/v10"
-
 	"github.com/eapache/queue"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -375,7 +373,7 @@ func TestRegularNode_CreateHost_PortBindingFailures(t *testing.T) {
 	})
 	t.Run("CreateHost with nil p2pClient", func(t *testing.T) {
 		regularNode := &RegularNode{
-			p2pClient:                     nil, 
+			p2pClient:                     nil,
 			submittedCvIndices:            make(map[string]map[string]bool),
 			strictOrderWhileSecretRequest: make(map[string][]string),
 			roundsData:                    make(map[string]RoundData),
@@ -465,7 +463,7 @@ func TestRegularNode_ConnectToLeader_TimeoutScenarios(t *testing.T) {
 
 		addrInfo, err := regularNode.ConnectToLeader(ctx, "127.0.0.1", "8081", validPeerID)
 
-		assert.Error(t, err, "Connection should fail with any error (cancellation or other)")
+		assert.Error(t, err, "Connection should fail with any error ")
 		_ = addrInfo
 	})
 
@@ -490,6 +488,18 @@ func TestRegularNode_ConnectToLeader_TimeoutScenarios(t *testing.T) {
 		assert.True(t, strings.Contains(err.Error(), "failed to parse") ||
 			strings.Contains(err.Error(), "failed to create peer info") ||
 			strings.Contains(err.Error(), "multiaddress"))
+	})
+
+	t.Run("DNS resolution failure - DNS name", func(t *testing.T) {
+		_, validPeerID := setupHostForConnectionTests(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		addrInfo, err := regularNode.ConnectToLeader(ctx, "nonexistent.example.com", "8081", validPeerID)
+
+		assert.Error(t, err)
+		_ = addrInfo
 	})
 
 	t.Run("Very short timeout - immediate timeout", func(t *testing.T) {
@@ -1203,7 +1213,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			p2pClient,
 			peerRepo,
 			revealRepo,
-			repo, 
+			repo,
 			batchRepo,
 			nodeInfoRepo,
 		)
@@ -1253,7 +1263,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			p2pClient,
 			peerRepo,
 			revealRepo,
-			repo, 
+			repo,
 			batchRepo,
 			nodeInfoRepo,
 		)
@@ -1295,7 +1305,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			revealRepo,
 			commitRepo,
 			batchRepo,
-			repo, 
+			repo,
 		)
 		require.NoError(t, err)
 
@@ -1345,7 +1355,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			revealRepo,
 			commitRepo,
 			batchRepo,
-			repo, 
+			repo,
 		)
 		require.NoError(t, err)
 
@@ -1381,7 +1391,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			mockFallbackClient,
 			revealOrderService,
 			p2pClient,
-			repo, 
+			repo,
 			revealRepo,
 			commitRepo,
 			batchRepo,
@@ -1460,7 +1470,7 @@ func TestNewRegularNode_InvalidDependencyStates(t *testing.T) {
 			peerRepo,
 			revealRepo,
 			commitRepo,
-			repo, 
+			repo,
 			nodeInfoRepo,
 		)
 		require.NoError(t, err)
@@ -1720,7 +1730,7 @@ func TestNewRegularNode_ConstructorNilValidation(t *testing.T) {
 		_, err := NewRegularNode(
 			mockFallbackClient,
 			revealOrderService,
-			nil, 
+			nil,
 			peerRepo,
 			revealRepo,
 			commitRepo,
@@ -1751,11 +1761,11 @@ func TestNewRegularNode_ConstructorNilValidation(t *testing.T) {
 			mockFallbackClient,
 			revealOrderService,
 			p2pClient,
-			nil, 
-			nil, 
-			nil, 
-			nil, 
-			nil, 
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
 		)
 
 		assert.Error(t, err, "Expected error when repositories are nil")

--- a/nodes/regular/send_commit.go
+++ b/nodes/regular/send_commit.go
@@ -437,6 +437,7 @@ func (n *RegularNode) submitS(ctx context.Context, round string, trialNum string
 	roundData, err := n.regularCommitRepository.GetCommitByRound(ctx, round, trialNum)
 	if err != nil {
 		log.Printf("Failed to get regular commit for round %s with : %v", round, err)
+		return
 	}
 
 	secretValueBytes := roundData.SecretValue

--- a/nodes/regular/send_commit_test.go
+++ b/nodes/regular/send_commit_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/tokamak-network/DRB-node/pkg/fallback_ethclient"
 	"github.com/tokamak-network/DRB-node/utils"
 )
-
 
 func TestRegularNode_RoundData_Structure(t *testing.T) {
 	roundData := RoundData{
@@ -898,6 +898,61 @@ func TestRegularNode_processSecretRequest_NotMyEOA(t *testing.T) {
 	mockRevealRepo.AssertExpectations(t)
 }
 
+func TestRegularNode_processSecretRequest_MyEOA_GetCommitByRoundFails(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	mockRevealRepo := node.revealOrderRepository.(*MockRevealOrderRepository)
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	node.SetHalted(false)
+
+	testOp := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	node.SetRegularNodeEOA(testOp.Hex())
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("EOA_PRIVATE_KEY")
+	}()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	index := big.NewInt(0)
+
+	
+	revealOrder := &utils.RevealOrderData{
+		Round:        "100",
+		TrialNum:     "1",
+		OrderedNodes: []string{testOp.Hex()}, // Node's own EOA
+		RevealOrder:  []int{0},
+	}
+
+	mockRevealRepo.On("GetRevealOrder", mock.Anything, "100", "1").
+		Return(revealOrder, nil)
+
+	
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error: commit not found"))
+
+	
+	panicked := false
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			t.Errorf("PANIC occurred unexpectedly: %v", r)
+		}
+	}()
+
+
+	node.processSecretRequest(context.Background(), round, trialNum, index)
+
+
+	assert.False(t, panicked, "Function should handle error gracefully without panic")
+
+
+	mockRevealRepo.AssertExpectations(t)
+	mockCommitRepo.AssertExpectations(t)
+}
+
 func TestRegularNode_processSubmittedSecretRequest_Halted(t *testing.T) {
 	node := createTestNodeForSendCommit()
 	node.SetHalted(true)
@@ -958,6 +1013,60 @@ func TestRegularNode_processSubmittedSecretRequest_NotNextInOrder(t *testing.T) 
 	node.processSubmittedSecretRequest(context.Background(), round, trialNum, index)
 
 	mockRevealRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processSubmittedSecretRequest_MyEOA_GetCommitByRoundFails(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	mockRevealRepo := node.revealOrderRepository.(*MockRevealOrderRepository)
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	node.SetHalted(false)
+
+	testOp := common.HexToAddress("0x1234567890123456789012345678901234567890")
+	node.SetRegularNodeEOA(testOp.Hex())
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("EOA_PRIVATE_KEY")
+	}()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	index := big.NewInt(0) 
+
+
+	revealOrder := &utils.RevealOrderData{
+		Round:        "100",
+		TrialNum:     "1",
+		OrderedNodes: []string{"0xNode0", testOp.Hex()}, 
+		RevealOrder:  []int{0, 1},                      
+	}
+
+	mockRevealRepo.On("GetRevealOrder", mock.Anything, "100", "1").
+		Return(revealOrder, nil)
+
+
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error: commit not found"))
+
+
+	panicked := false
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			t.Errorf("PANIC occurred unexpectedly: %v", r)
+		}
+	}()
+
+	node.processSubmittedSecretRequest(context.Background(), round, trialNum, index)
+
+	
+	assert.False(t, panicked, "Function should handle error gracefully without panic")
+
+	
+	mockRevealRepo.AssertExpectations(t)
+	mockCommitRepo.AssertExpectations(t)
 }
 
 func TestRegularNode_allCosReceivedUnlockedRegular_AllReceived(t *testing.T) {
@@ -1448,6 +1557,354 @@ func TestRegularNode_processCommitRequest_ABILoadError(t *testing.T) {
 	_ = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
 }
 
+func TestRegularNode_processCommitRequest_ExecuteTransactionNetworkFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	networkError := errors.New("network error: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, networkError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	assert.Contains(t, err.Error(), "network error")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ExecuteTransactionContextTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	ctxTimeoutError := context.DeadlineExceeded
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, ctxTimeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0) 
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ExecuteTransactionAllRetriesExhausted(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+	retryExhaustedError := errors.New("transaction failed after 3 retries: all RPCs failed")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, retryExhaustedError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_GetCommitByRoundError(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	dbError := errors.New("database error: connection pool exhausted")
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, dbError)
+
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get commit by round")
+	assert.Contains(t, err.Error(), "database error")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ExecuteTransactionConnectionTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	timeoutError := errors.New("network error: i/o timeout")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, timeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0) // Index 0
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	assert.Contains(t, err.Error(), "i/o timeout")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ExecuteTransactionEOFError(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	eofError := errors.New("unexpected EOF")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, eofError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	assert.Contains(t, err.Error(), "unexpected EOF")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ExecuteTransactionIntermittentFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	callCount := 0
+	networkError := errors.New("network error: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				callCount++
+
+				return nil, nil, networkError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
 func TestRegularNode_processCosRequest_Halted(t *testing.T) {
 	node := createTestNodeForSendCommit()
 	node.SetHalted(true)
@@ -1487,12 +1944,1131 @@ func TestRegularNode_processCosRequest_EOANotInIndices(t *testing.T) {
 
 	round := big.NewInt(100)
 	trialNum := big.NewInt(1)
-	packedIndices := big.NewInt(1) // Only index 1
+	packedIndices := big.NewInt(1)
 	indicesLength := big.NewInt(1)
 
 	err := node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
 
 	assert.NoError(t, err)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionNetworkFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	// Mock ExecuteTransaction to return network error
+	networkError := errors.New("network error: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, networkError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	assert.Contains(t, err.Error(), "network error")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionContextTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	ctxTimeoutError := context.DeadlineExceeded
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, ctxTimeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionAllRetriesExhausted(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	retryExhaustedError := errors.New("transaction failed after 3 retries: all RPCs failed")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, retryExhaustedError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_GetCommitByRoundError(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	dbError := errors.New("database error: connection pool exhausted")
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, dbError)
+
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get commit by round")
+	assert.Contains(t, err.Error(), "database error")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionConnectionTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	timeoutError := errors.New("network error: i/o timeout")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, timeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	assert.Contains(t, err.Error(), "i/o timeout")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionEOFError(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	eofError := errors.New("unexpected EOF")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, eofError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	assert.Contains(t, err.Error(), "unexpected EOF")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCosRequest_ExecuteTransactionIntermittentFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cos:      [32]byte{1, 2, 3},
+		}, nil)
+
+	networkError := errors.New("network error: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCo" {
+				return nil, nil, networkError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0) // Index 0
+	indicesLength := big.NewInt(1)
+
+	err = node.processCosRequest(context.Background(), round, trialNum, packedIndices, indicesLength)
+
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCo transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_submitS_ExecuteTransactionNetworkFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:       "100",
+			TrialNum:    "1",
+			SecretValue: [32]byte{1, 2, 3, 4, 5},
+		}, nil)
+
+	// Mock ExecuteTransaction to return network error
+	networkError := errors.New("network error: connection refused")
+	mockEth := &MockEthService{
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitS" {
+				return nil, nil, networkError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	node.submitS(context.Background(), "100", "1")
+
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_submitS_ExecuteTransactionContextTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:       "100",
+			TrialNum:    "1",
+			SecretValue: [32]byte{1, 2, 3, 4, 5},
+		}, nil)
+
+	ctxTimeoutError := context.DeadlineExceeded
+	mockEth := &MockEthService{
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitS" {
+				return nil, nil, ctxTimeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	node.submitS(context.Background(), "100", "1")
+
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_submitS_ExecuteTransactionAllRetriesExhausted(t *testing.T) {
+	node := createTestNodeForSendCommit()
+
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	// Mock commit repository
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:       "100",
+			TrialNum:    "1",
+			SecretValue: [32]byte{1, 2, 3, 4, 5},
+		}, nil)
+
+	retryExhaustedError := errors.New("transaction failed after 3 retries: all RPCs failed")
+	mockEth := &MockEthService{
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitS" {
+				return nil, nil, retryExhaustedError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	node.submitS(context.Background(), "100", "1")
+
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_submitS_GetCommitByRoundReturnsNil_GracefulHandling(t *testing.T) {
+	node := createTestNodeForSendCommit()
+
+	os.Setenv("EOA_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error: commit not found"))
+
+	panicked := false
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			t.Errorf("PANIC occurred unexpectedly: %v", r)
+		}
+	}()
+
+	node.submitS(context.Background(), "100", "1")
+
+	assert.False(t, panicked, "Function should handle error gracefully without panic")
+
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_TransactionSentButReceiptWaitFails(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	receiptTimeoutError := errors.New("transaction 0x123 stuck in mempool after 5s")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, receiptTimeoutError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_DuplicateTransactionPrevention(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	duplicateTxError := errors.New("replacement transaction underpriced")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, duplicateTxError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ContextCancelledDuringReceiptWait(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	ctxCancelledError := context.DeadlineExceeded
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+
+				select {
+				case <-ctx.Done():
+					return nil, nil, ctxCancelledError
+				default:
+					return nil, nil, ctxCancelledError
+				}
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(ctx, round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ConcurrentSubmissions(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").Return(&utils.CommitData{
+		Round:    "100",
+		TrialNum: "1",
+		Cvs:      [32]byte{1, 2, 3},
+	}, nil).Times(3) 
+
+	callCount := int32(0)
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				atomic.AddInt32(&callCount, 1)
+				return nil, nil, nil
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	var wg sync.WaitGroup
+	errors := make([]error, 3)
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errors[idx] = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+		}(i)
+	}
+
+	wg.Wait()
+
+	
+	assert.Equal(t, int32(3), callCount, "All concurrent calls should execute")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_GasEstimationFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	// Simulate gas estimation failure
+	gasEstimationError := errors.New("gas estimation failed after 3 attempts, submitCv transaction will revert")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, gasEstimationError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	// Should return error when gas estimation fails
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_ChainIDFetchFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	chainIDError := errors.New("failed to fetch chain ID after 3 attempts for submitCv. Errors: Attempt 1: connection refused; Attempt 2: connection refused; Attempt 3: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, chainIDError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_TransactionSigningFailure(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	signingError := errors.New("failed to sign tx after 3 retries: invalid private key")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, signingError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	// Should return error when signing fails
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_PartialSuccess_TransactionSentButReceiptTimeout(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+
+	partialSuccessError := errors.New("transaction 0xabc123 stuck in mempool after 5s")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, partialSuccessError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	assert.Error(t, err)
+
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_AllFallbackClientsFail(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	allClientsFailedError := errors.New("all RPCs failed: connection refused")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, allClientsFailedError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute submitCv transaction")
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_processCommitRequest_NonceMismatchError(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	node.SetHalted(false)
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	defer func() {
+		os.Unsetenv("EOA_PRIVATE_KEY")
+		os.Unsetenv("CONTRACT_ADDRESS")
+	}()
+
+	mockCommitRepo := node.regularCommitRepository.(*MockRegularCommitRepository)
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(&utils.CommitData{
+			Round:    "100",
+			TrialNum: "1",
+			Cvs:      [32]byte{1, 2, 3},
+		}, nil)
+
+	nonceError := errors.New("nonce too low")
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+		ExecuteTransactionFunc: func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error) {
+			if method == "submitCv" {
+				return nil, nil, nonceError
+			}
+			return nil, nil, nil
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	err = node.processCommitRequest(context.Background(), round, trialNum, packedIndices)
+
+	// Should handle nonce error
+	assert.Error(t, err)
+	mockCommitRepo.AssertExpectations(t)
+}
+
+func TestRegularNode_receiveCommitRequest_MultipleEvents_OneFails_OthersContinue(t *testing.T) {
+	node := createTestNodeForReceiveCommitRequest()
+	mockClient := new(MockFallbackEthClient)
+	mockCommitRepo := new(MockRegularCommitRepository)
+	mockBatchRepo := new(MockBatchRepository)
+	node.fallbackEthClient = mockClient
+	node.regularCommitRepository = mockCommitRepo
+	node.batchRepository = mockBatchRepo
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("EOA_PRIVATE_KEY")
+	}()
+
+	parsedABI, err := utils.LoadContractABI("contract/abi/Commit2RevealDRB.json")
+	require.NoError(t, err)
+
+	requestedToSubmitCvSig := parsedABI.Events["RequestedToSubmitCv"].ID
+	statusSig := parsedABI.Events["Status"].ID
+
+	mockSub := &MockSubscription{
+		errChan: make(chan error),
+	}
+	mockSub.On("Unsubscribe").Return()
+
+	eventCount := int32(0)
+	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			logs := args.Get(2).(chan<- types.Log)
+
+			go func() {
+				// First event - will fail
+				time.Sleep(50 * time.Millisecond)
+				round1 := big.NewInt(100)
+				trialNum1 := big.NewInt(1)
+				packedIndices1 := big.NewInt(0)
+				eventData1, _ := parsedABI.Events["RequestedToSubmitCv"].Inputs.Pack(round1, trialNum1, packedIndices1)
+				logs <- types.Log{
+					Topics:      []common.Hash{requestedToSubmitCvSig},
+					Data:        eventData1,
+					BlockNumber: 12345,
+					Removed:     false,
+				}
+				atomic.AddInt32(&eventCount, 1)
+
+				// Second event - should still process
+				time.Sleep(100 * time.Millisecond)
+				round2 := big.NewInt(100)
+				trialNum2 := big.NewInt(1)
+				state := big.NewInt(1)
+				eventData2, _ := parsedABI.Events["Status"].Inputs.Pack(round2, trialNum2, state)
+				logs <- types.Log{
+					Topics:      []common.Hash{statusSig},
+					Data:        eventData2,
+					BlockNumber: 12346,
+					Removed:     false,
+				}
+				atomic.AddInt32(&eventCount, 1)
+			}()
+		}).Return(mockSub, nil)
+
+	mockClient.On("BlockTimestamp", mock.Anything, mock.Anything).
+		Return(uint64(time.Now().Unix()), nil)
+
+
+	mockBatchRepo.On("DeleteOldRoundDataForRegularNode", mock.Anything, "100").
+		Return(nil).Maybe()
+
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error")).Once()
+
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	go node.receiveCommitRequest(ctx)
+
+	<-ctx.Done()
+	time.Sleep(100 * time.Millisecond)
+
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&eventCount), int32(1), "Events should be processed even if one fails")
+	mockClient.AssertExpectations(t)
+	mockCommitRepo.AssertExpectations(t)
+	mockBatchRepo.AssertExpectations(t)
 }
 
 func TestRegularNode_unpackIndices_EdgeCases(t *testing.T) {
@@ -2139,6 +3715,178 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_BlockTimestampErro
 	time.Sleep(50 * time.Millisecond) // Give goroutine time to cleanup and call Unsubscribe
 
 	mockClient.AssertExpectations(t)
+	mockSub.AssertExpectations(t)
+}
+
+func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_ProcessCommitRequestErrorHandling(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	mockClient := new(MockFallbackEthClient)
+	mockCommitRepo := new(MockRegularCommitRepository)
+	node.fallbackEthClient = mockClient
+	node.regularCommitRepository = mockCommitRepo
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("EOA_PRIVATE_KEY")
+	}()
+
+	parsedABI, err := utils.LoadContractABI("contract/abi/Commit2RevealDRB.json")
+	require.NoError(t, err)
+
+	requestedToSubmitCvSig := parsedABI.Events["RequestedToSubmitCv"].ID
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	eventData, err := parsedABI.Events["RequestedToSubmitCv"].Inputs.Pack(round, trialNum, packedIndices)
+	require.NoError(t, err)
+
+	mockSub := &MockSubscription{
+		errChan: make(chan error),
+	}
+	mockSub.On("Unsubscribe").Return()
+
+	eventSent := false
+	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if !eventSent {
+				logs := args.Get(2).(chan<- types.Log)
+
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					logs <- types.Log{
+						Topics:      []common.Hash{requestedToSubmitCvSig},
+						Data:        eventData,
+						BlockNumber: 12345,
+						Removed:     false,
+					}
+				}()
+				eventSent = true
+			}
+		}).Return(mockSub, nil)
+
+	mockClient.On("BlockTimestamp", mock.Anything, big.NewInt(12345)).
+		Return(uint64(time.Now().Unix()), nil)
+
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error: commit not found"))
+
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	go node.receiveCommitRequest(ctx)
+
+	<-ctx.Done()
+
+	// Give the goroutine time to process error and log it
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify that error was handled gracefully 
+	mockClient.AssertExpectations(t)
+	mockCommitRepo.AssertExpectations(t)
+	mockSub.AssertExpectations(t)
+}
+
+func TestRegularNode_receiveCommitRequest_RequestedToSubmitCo_ProcessCosRequestErrorHandling(t *testing.T) {
+	node := createTestNodeForSendCommit()
+	mockClient := new(MockFallbackEthClient)
+	mockCommitRepo := new(MockRegularCommitRepository)
+	node.fallbackEthClient = mockClient
+	node.regularCommitRepository = mockCommitRepo
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	eoaAddress := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+	os.Setenv("EOA_PRIVATE_KEY", hex.EncodeToString(crypto.FromECDSA(privateKey)))
+	defer func() {
+		os.Unsetenv("CONTRACT_ADDRESS")
+		os.Unsetenv("EOA_PRIVATE_KEY")
+	}()
+
+	parsedABI, err := utils.LoadContractABI("contract/abi/Commit2RevealDRB.json")
+	require.NoError(t, err)
+
+	requestedToSubmitCoSig := parsedABI.Events["RequestedToSubmitCo"].ID
+
+	round := big.NewInt(100)
+	trialNum := big.NewInt(1)
+	indicesLength := big.NewInt(1)
+	packedIndices := big.NewInt(0)
+
+	eventData, err := parsedABI.Events["RequestedToSubmitCo"].Inputs.Pack(round, trialNum, indicesLength, packedIndices)
+	require.NoError(t, err)
+
+	mockSub := &MockSubscription{
+		errChan: make(chan error),
+	}
+	mockSub.On("Unsubscribe").Return()
+
+	eventSent := false
+	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if !eventSent {
+				logs := args.Get(2).(chan<- types.Log)
+
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					logs <- types.Log{
+						Topics:      []common.Hash{requestedToSubmitCoSig},
+						Data:        eventData,
+						BlockNumber: 12345,
+						Removed:     false,
+					}
+				}()
+				eventSent = true
+			}
+		}).Return(mockSub, nil)
+
+	mockClient.On("BlockTimestamp", mock.Anything, big.NewInt(12345)).
+		Return(uint64(time.Now().Unix()), nil)
+
+	// Mock GetCommitByRound to return error, which will cause processCosRequest to fail
+	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
+		Return(nil, errors.New("database error: commit not found"))
+
+	mockEth := &MockEthService{
+		GetActivatedOperatorsCachedFunc: func() []common.Address {
+			return []common.Address{eoaAddress}
+		},
+	}
+	originalService := eth.Service
+	eth.Service = mockEth
+	defer func() { eth.Service = originalService }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	go node.receiveCommitRequest(ctx)
+
+	<-ctx.Done()
+
+	
+	time.Sleep(100 * time.Millisecond)
+
+
+	mockClient.AssertExpectations(t)
+	mockCommitRepo.AssertExpectations(t)
 	mockSub.AssertExpectations(t)
 }
 

--- a/utils/streamHandler_test.go
+++ b/utils/streamHandler_test.go
@@ -1,12 +1,22 @@
 package utils
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +44,7 @@ func TestCreateStream(t *testing.T) {
 	// Get host2's address information
 	addrs := host2.Addrs()
 	require.NotEmpty(t, addrs, "Host2 should have at least one address")
-	
+
 	// Extract port from the first address
 	_ = addrs // Mark as used for now
 
@@ -81,10 +91,10 @@ func TestCreateStream(t *testing.T) {
 	t.Run("valid connection parameters", func(t *testing.T) {
 		// For this test, we need proper host configuration
 		// This is more of an integration test that requires proper setup
-		
+
 		// Extract the peer ID and address info from host2
 		peerID := host2.ID().String()
-		
+
 		// Extract port from host2's listening address
 		var actualPort string
 		for _, addr := range host2.Addrs() {
@@ -106,7 +116,7 @@ func TestCreateStream(t *testing.T) {
 		// Note: This test might fail due to timing or network issues
 		// In a real scenario, you'd need proper host discovery and connection setup
 		stream, err := CreateStream(context.Background(), host1, nodeInfo, string(protocolID))
-		
+
 		// We expect this to fail in the test environment due to address resolution
 		// but we're testing that the function handles the parameters correctly
 		if err != nil {
@@ -195,7 +205,7 @@ func TestCreateStreamInputValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stream, err := CreateStream(context.Background(), host, tt.nodeInfo, tt.protocol)
-			
+
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, stream)
@@ -207,4 +217,514 @@ func TestCreateStreamInputValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Mock stream implementation for testing DecodeJSONWithContext
+type mockStream struct {
+	readBuffer  *bytes.Buffer
+	writeBuffer *bytes.Buffer
+	closed      bool
+	resetCalled bool
+	mu          sync.Mutex
+	conn        *mockConn
+	readError   error
+	closeOnRead bool
+}
+
+type mockConn struct {
+	remotePeer peer.ID
+}
+
+func newMockStream() *mockStream {
+	mockPeerID, _ := peer.Decode("12D3KooWTestPeerID1234567890123456789012345678901234567890")
+	return &mockStream{
+		readBuffer:  new(bytes.Buffer),
+		writeBuffer: new(bytes.Buffer),
+		closed:      false,
+		resetCalled: false,
+		conn:        &mockConn{remotePeer: mockPeerID},
+	}
+}
+
+func (m *mockStream) Read(p []byte) (n int, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.readError != nil {
+		return 0, m.readError
+	}
+	if m.closeOnRead && m.readBuffer.Len() == 0 {
+		return 0, io.EOF
+	}
+	return m.readBuffer.Read(p)
+}
+
+func (m *mockStream) Write(p []byte) (n int, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.writeBuffer.Write(p)
+}
+
+func (m *mockStream) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *mockStream) Reset() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resetCalled = true
+	return nil
+}
+
+func (m *mockStream) SetDeadline(t time.Time) error      { return nil }
+func (m *mockStream) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockStream) SetWriteDeadline(t time.Time) error { return nil }
+func (m *mockStream) ID() string                         { return "mock-stream-id" }
+func (m *mockStream) Protocol() protocol.ID              { return protocol.ID("/test") }
+func (m *mockStream) SetProtocol(protocol.ID) error      { return nil }
+func (m *mockStream) Stat() network.Stats                { return network.Stats{} }
+func (m *mockStream) Conn() network.Conn                 { return m.conn }
+func (m *mockStream) CloseWrite() error                  { m.closed = true; return nil }
+func (m *mockStream) CloseRead() error                   { m.closed = true; return nil }
+func (m *mockStream) Scope() network.StreamScope         { return nil }
+
+func (m *mockConn) ID() string                                        { return "mock-conn-id" }
+func (m *mockConn) Close() error                                      { return nil }
+func (m *mockConn) LocalPeer() peer.ID                                { return "" }
+func (m *mockConn) RemotePeer() peer.ID                               { return m.remotePeer }
+func (m *mockConn) LocalPrivateKey() libp2pcrypto.PrivKey             { return nil }
+func (m *mockConn) RemotePublicKey() libp2pcrypto.PubKey              { return nil }
+func (m *mockConn) LocalMultiaddr() multiaddr.Multiaddr               { return nil }
+func (m *mockConn) RemoteMultiaddr() multiaddr.Multiaddr              { return nil }
+func (m *mockConn) GetStreams() []network.Stream                      { return nil }
+func (m *mockConn) Stat() network.ConnStats                           { return network.ConnStats{} }
+func (m *mockConn) Scope() network.ConnScope                          { return nil }
+func (m *mockConn) IsClosed() bool                                    { return false }
+func (m *mockConn) ConnState() network.ConnectionState                { return network.ConnectionState{} }
+func (m *mockConn) NewStream(context.Context) (network.Stream, error) { return nil, nil }
+
+// TestDecodeJSONWithContext tests the DecodeJSONWithContext function with various scenarios
+func TestDecodeJSONWithContext(t *testing.T) {
+	t.Run("valid JSON decoding", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "1", req.Round)
+		assert.Equal(t, "1", req.TrialNum)
+		assert.Equal(t, "0x123", req.EOAAddress)
+		assert.False(t, stream.resetCalled)
+	})
+
+	t.Run("malformed JSON - invalid syntax", func(t *testing.T) {
+		stream := newMockStream()
+		invalidJSON := `{"round":"1","trial_num":"1"` // Missing closing brace
+		stream.readBuffer.WriteString(invalidJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+		// JSON decoder returns "unexpected EOF" for incomplete JSON
+		assert.True(t, strings.Contains(err.Error(), "unexpected") || strings.Contains(err.Error(), "EOF"))
+		assert.False(t, stream.resetCalled)
+	})
+
+	t.Run("malformed JSON - invalid characters", func(t *testing.T) {
+		stream := newMockStream()
+		invalidJSON := `{"round":"1","trial_num":invalid}` // Invalid value
+		stream.readBuffer.WriteString(invalidJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+		assert.False(t, stream.resetCalled)
+	})
+
+	t.Run("malformed JSON - wrong data type", func(t *testing.T) {
+		stream := newMockStream()
+		invalidJSON := `{"round":123,"trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(invalidJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot unmarshal number")
+		assert.Contains(t, err.Error(), "round")
+		assert.Empty(t, req.Round)
+	})
+	t.Run("empty stream", func(t *testing.T) {
+		stream := newMockStream()
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "EOF")
+	})
+
+	t.Run("stream closed mid-transmission", func(t *testing.T) {
+		stream := newMockStream()
+		partialJSON := `{"round":"1","trial_num":"1"`
+		stream.readBuffer.WriteString(partialJSON)
+		stream.closeOnRead = true
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("corrupted bytes in stream", func(t *testing.T) {
+		stream := newMockStream()
+		corruptedJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}\x00\xFF\xFE` // Invalid bytes after valid JSON
+		stream.readBuffer.WriteString(corruptedJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err, "Decoder should handle corrupted bytes after valid JSON")
+		assert.Equal(t, "1", req.Round)
+		assert.Equal(t, "1", req.TrialNum)
+		assert.Equal(t, "0x123", req.EOAAddress)
+	})
+
+	t.Run("oversized payload - very large JSON", func(t *testing.T) {
+		stream := newMockStream()
+		// Create a very large JSON payload
+		largeData := strings.Repeat("x", 1000000) // 1MB of data
+		largeJSON := `{"round":"1","trial_num":"1","eoa_address":"` + largeData + `"}`
+		stream.readBuffer.WriteString(largeJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		if err != nil {
+			assert.Error(t, err)
+		}
+	})
+
+	t.Run("deeply nested JSON structure", func(t *testing.T) {
+		stream := newMockStream()
+		nestedJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123","nested":` + strings.Repeat(`{"a":`, 1000) + `"value"` + strings.Repeat(`}`, 1000) + `}`
+		stream.readBuffer.WriteString(nestedJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		if err != nil {
+			assert.Error(t, err)
+		}
+	})
+
+	t.Run("type mismatch - wrong struct type", func(t *testing.T) {
+		stream := newMockStream()
+		// JSON for BroadcastMessage but decoding into CommitRequest
+		broadcastJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123","type":"cvs","data":"0x1234","signer_eoa":"0x5678","signature":"0xabcd"}`
+		stream.readBuffer.WriteString(broadcastJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		// JSON decoder ignores extra fields and sets missing fields to zero values
+		assert.NoError(t, err, "Decoder should handle type mismatch gracefully")
+		assert.Equal(t, "1", req.Round)
+		assert.Equal(t, "1", req.TrialNum)
+		assert.Equal(t, "0x123", req.EOAAddress)
+		assert.Empty(t, req.UniqueKey)
+		assert.Equal(t, [32]byte{}, req.Cvs)
+	})
+	t.Run("missing required fields", func(t *testing.T) {
+		stream := newMockStream()
+		incompleteJSON := `{"round":"1"}` // Missing trial_num and eoa_address
+		stream.readBuffer.WriteString(incompleteJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "1", req.Round)
+		assert.Empty(t, req.TrialNum)
+		assert.Empty(t, req.EOAAddress)
+	})
+
+	t.Run("extra fields in JSON", func(t *testing.T) {
+		stream := newMockStream()
+		extraFieldsJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123","extra_field":"should_be_ignored"}`
+		stream.readBuffer.WriteString(extraFieldsJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		// Should decode successfully, extra fields are ignored
+		assert.NoError(t, err)
+		assert.Equal(t, "1", req.Round)
+	})
+
+	t.Run("multiple JSON objects in stream", func(t *testing.T) {
+		stream := newMockStream()
+		// Write two JSON objects
+		firstJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		secondJSON := `{"round":"2","trial_num":"2","eoa_address":"0x456"}`
+		stream.readBuffer.WriteString(firstJSON + secondJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		// Should decode only the first object
+		assert.NoError(t, err)
+		assert.Equal(t, "1", req.Round)
+	})
+
+	t.Run("context timeout during decoding", func(t *testing.T) {
+		// Create a slow-reading stream that will timeout
+		stream := newMockStream()
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+
+		// Write valid JSON
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(ctx, stream, &req)
+
+		// Should timeout immediately since context is already expired
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON decode timeout")
+		assert.True(t, stream.resetCalled)
+	})
+
+	t.Run("context cancellation during decoding", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel immediately
+		cancel()
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(ctx, stream, &req)
+
+		// Should cancel and reset stream
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON decode cancelled")
+		assert.True(t, stream.resetCalled)
+	})
+
+	t.Run("context timeout with immediate timeout", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(ctx, stream, &req)
+
+		// Context already expired, should timeout immediately
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON decode timeout")
+		assert.True(t, stream.resetCalled)
+	})
+
+	t.Run("nil target struct", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		err := DecodeJSONWithContext(context.Background(), stream, nil)
+
+		assert.Error(t, err) // do not panic return error
+	})
+
+	t.Run("stream read error", func(t *testing.T) {
+		stream := newMockStream()
+		stream.readError = errors.New("network read error")
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "network read error")
+	})
+
+	t.Run("valid BroadcastMessage decoding", func(t *testing.T) {
+		stream := newMockStream()
+		// Create a BroadcastMessage and encode it to JSON to get the correct format
+		testMsg := BroadcastMessage{
+			Round:      "1",
+			TrialNum:   "1",
+			EOAAddress: "0x123",
+			MessageID:  "msg1",
+			Type:       "cvs",
+			Data:       [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			SignerEOA:  "0x5678",
+			Signature:  []byte{0xab, 0xcd},
+		}
+		broadcastJSONBytes, err := json.Marshal(testMsg)
+		require.NoError(t, err)
+		stream.readBuffer.Write(broadcastJSONBytes)
+
+		var msg BroadcastMessage
+		err = DecodeJSONWithContext(context.Background(), stream, &msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "1", msg.Round)
+		assert.Equal(t, "cvs", msg.Type)
+		assert.Equal(t, testMsg.Data, msg.Data)
+	})
+
+	t.Run("valid RegistrationRequest decoding", func(t *testing.T) {
+		stream := newMockStream()
+		// Create a RegistrationRequest and encode it to JSON to get the correct format
+		testReq := RegistrationRequest{
+			EOAAddress: "0x123",
+			Signature:  []byte{0xab, 0xcd, 0xef},
+			PeerID:     "12D3KooWTest1234567890123456789012345678901234567890",
+		}
+		regJSONBytes, err := json.Marshal(testReq)
+		require.NoError(t, err)
+		stream.readBuffer.Write(regJSONBytes)
+
+		var req RegistrationRequest
+		err = DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "0x123", req.EOAAddress)
+		assert.Equal(t, "12D3KooWTest1234567890123456789012345678901234567890", req.PeerID)
+		assert.Equal(t, testReq.Signature, req.Signature)
+	})
+
+	t.Run("JSON with null values", func(t *testing.T) {
+		stream := newMockStream()
+		nullJSON := `{"round":null,"trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(nullJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Empty(t, req.Round, "null should be converted to empty string")
+		assert.Equal(t, "1", req.TrialNum)
+		assert.Equal(t, "0x123", req.EOAAddress)
+	})
+
+	t.Run("JSON with empty strings", func(t *testing.T) {
+		stream := newMockStream()
+		emptyJSON := `{"round":"","trial_num":"","eoa_address":""}`
+		stream.readBuffer.WriteString(emptyJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Empty(t, req.Round)
+		assert.Empty(t, req.TrialNum)
+		assert.Empty(t, req.EOAAddress)
+	})
+
+	t.Run("concurrent decoding calls", func(t *testing.T) {
+		// Test that multiple concurrent calls don't interfere
+		stream1 := newMockStream()
+		stream2 := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream1.readBuffer.WriteString(validJSON)
+		stream2.readBuffer.WriteString(validJSON)
+
+		var req1, req2 CommitRequest
+		var err1, err2 error
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			err1 = DecodeJSONWithContext(context.Background(), stream1, &req1)
+		}()
+
+		go func() {
+			defer wg.Done()
+			err2 = DecodeJSONWithContext(context.Background(), stream2, &req2)
+		}()
+
+		wg.Wait()
+
+		assert.NoError(t, err1)
+		assert.NoError(t, err2)
+		assert.Equal(t, "1", req1.Round)
+		assert.Equal(t, "1", req2.Round)
+	})
+
+	t.Run("stream reset verification on timeout", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		// Use a context that's already expired
+		ctx, cancel := context.WithTimeout(context.Background(), 0)
+		defer cancel()
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(ctx, stream, &req)
+
+		assert.Error(t, err)
+		assert.True(t, stream.resetCalled, "Stream should be reset on timeout")
+	})
+
+	t.Run("stream reset verification on cancellation", func(t *testing.T) {
+		stream := newMockStream()
+		validJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(validJSON)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel immediately
+		cancel()
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(ctx, stream, &req)
+
+		assert.Error(t, err)
+		assert.True(t, stream.resetCalled, "Stream should be reset on cancellation")
+	})
+
+	t.Run("JSON with special characters", func(t *testing.T) {
+		stream := newMockStream()
+		specialJSON := `{"round":"1","trial_num":"1","eoa_address":"0x123\n\t\"\\"}`
+		stream.readBuffer.WriteString(specialJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "1", req.Round)
+		assert.Equal(t, "1", req.TrialNum)
+		expectedAddress := "0x123\n\t\"\\"
+		assert.Equal(t, expectedAddress, req.EOAAddress)
+	})
+
+	t.Run("very long field values", func(t *testing.T) {
+		stream := newMockStream()
+		longValue := strings.Repeat("a", 100000)
+		longJSON := `{"round":"` + longValue + `","trial_num":"1","eoa_address":"0x123"}`
+		stream.readBuffer.WriteString(longJSON)
+
+		var req CommitRequest
+		err := DecodeJSONWithContext(context.Background(), stream, &req)
+
+		if err != nil {
+			assert.Error(t, err)
+		} else {
+			assert.Equal(t, longValue, req.Round)
+		}
+	})
 }


### PR DESCRIPTION
 ## Summary
  - Significantly expanded unit test coverage across the commit-reveal and node packages (~4,700+ lines of new tests)
  - Improved error handling in broadcast and commit submission flows
  - Fixed race conditions in merkle root generation

  ## Key Changes

  **Bug Fixes:**
  - Added missing `return` statement in `submitS` when `roundData` retrieval fails (`nodes/regular/send_commit.go`)
  - Fixed race condition in `GenerateMerkleRoot` by using `CompareAndSwapSubmittingMerkleRoot` at the start of the function (`nodes/leader/accept_commit.go`)

  **Improved Error Handling:**
  - Added nil checks for `nodeInfoRepository` and `p2pClient` in `processDeactivated`
  - Added validation for missing node info entries in `performReliableBroadcast` and `performReliableBroadcastSync`
  - Added proper error handling for multiaddr parsing failures

  **New Test Coverage:**
  - `commit-reveal2/commit_test.go` (+576 lines)
  - `nodes/regular/send_commit_test.go` (+1,862 lines)
  - `nodes/leader/accept_commit_test.go` (+964 lines)
  - `nodes/leader/broad_cast_test.go` (+755 lines)
  - `utils/streamHandler_test.go` (+532 lines)
  - `commit-reveal2/merkleTree_test.go` (+124 lines)

  ## Test plan
  - [ ] Run `go test ./commit-reveal2/...` to verify commit-reveal test coverage
  - [ ] Run `go test ./nodes/leader/...` to verify leader node tests
  - [ ] Run `go test ./nodes/regular/...` to verify regular node tests
  - [ ] Run `go test ./utils/...` to verify stream handler tests
  - [ ] Run tests with `-race` flag to verify race condition fixes