### PR TITLE
refactor: unify NewClient and improve test coverage

### DIFF
--- a/nodes/regular/handler_test.go
+++ b/nodes/regular/handler_test.go
@@ -1985,7 +1985,7 @@ func TestRegularNodeHandler_activateOnChain_InvalidPrivateKey(t *testing.T) {
 	err := handler.activateOnChain(context.Background(), abiFilePath)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to decode leader private key")
+	assert.Contains(t, err.Error(), "failed to decode private key")
 }
 
 func TestRegularNodeHandler_activateOnChain_TransactionError(t *testing.T) {

--- a/pkg/fallback_ethclient/fallback_rpc_test.go
+++ b/pkg/fallback_ethclient/fallback_rpc_test.go
@@ -793,6 +793,48 @@ func TestFallbackRPCClient_EstimateGas(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(21000), gas)
 	})
+
+	t.Run("all servers fail", func(t *testing.T) {
+		server1 := createMockRPCServer(t, func(req *jsonRPCRequest) *jsonRPCResponse {
+			if req.Method == "eth_estimateGas" {
+				return &jsonRPCResponse{
+					JSONRPC: "2.0",
+					Error: &rpcError{
+						Code:    -32000,
+						Message: "gas estimation failed",
+					},
+					ID: req.ID,
+				}
+			}
+			return &jsonRPCResponse{JSONRPC: "2.0", Result: "0x1", ID: req.ID}
+		})
+		defer server1.Close()
+
+		server2 := createMockRPCServer(t, func(req *jsonRPCRequest) *jsonRPCResponse {
+			if req.Method == "eth_estimateGas" {
+				return &jsonRPCResponse{
+					JSONRPC: "2.0",
+					Error: &rpcError{
+						Code:    -32000,
+						Message: "execution reverted",
+					},
+					ID: req.ID,
+				}
+			}
+			return &jsonRPCResponse{JSONRPC: "2.0", Result: "0x1", ID: req.ID}
+		})
+		defer server2.Close()
+
+		client, err := NewFallbackRPCClient([]string{server1.URL, server2.URL})
+		require.NoError(t, err)
+		defer client.Close()
+
+		gas, err := client.EstimateGas(context.Background(), ethereum.CallMsg{})
+		assert.Error(t, err)
+		assert.Equal(t, uint64(0), gas)
+		// Returns the last error after all fallbacks exhausted
+		assert.Contains(t, err.Error(), "execution reverted")
+	})
 }
 
 func TestFallbackRPCClient_ChainID(t *testing.T) {

--- a/utils/clients.go
+++ b/utils/clients.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -43,10 +43,11 @@ func LoadContractABI(filename string) (abi.ABI, error) {
 	return parsedABI, nil
 }
 
-func NewLeaderClient(abiPath string) (*Client, error) {
+// NewClient creates a new Client with the given ABI path and private key.
+func NewClient(abiPath string, privateKeyHex string) (*Client, error) {
 	contractAddressStr := appconfig.Get().ContractAddress
 	if contractAddressStr == "" {
-		log.Fatal("CONTRACT_ADDRESS is not set in environment variables.")
+		return nil, errors.New("CONTRACT_ADDRESS is not set in environment variables")
 	}
 	contractAddress := common.HexToAddress(contractAddressStr)
 
@@ -55,14 +56,13 @@ func NewLeaderClient(abiPath string) (*Client, error) {
 		return nil, fmt.Errorf("failed to load contract ABI: %v", err)
 	}
 
-	privateKeyHex := appconfig.Get().LeaderPrivateKey
 	if privateKeyHex == "" {
-		log.Fatal("LEADER_PRIVATE_KEY is not set in environment variables.")
+		return nil, errors.New("private key is not provided")
 	}
 
 	privateKey, err := crypto.HexToECDSA(privateKeyHex)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode leader private key: %v", err)
+		return nil, fmt.Errorf("failed to decode private key: %v", err)
 	}
 
 	return &Client{
@@ -72,31 +72,20 @@ func NewLeaderClient(abiPath string) (*Client, error) {
 	}, nil
 }
 
+// NewLeaderClient creates a new Client using the leader's private key.
+func NewLeaderClient(abiPath string) (*Client, error) {
+	privateKeyHex := appconfig.Get().LeaderPrivateKey
+	if privateKeyHex == "" {
+		return nil, errors.New("LEADER_PRIVATE_KEY is not set in environment variables")
+	}
+	return NewClient(abiPath, privateKeyHex)
+}
+
+// NewEOAClient creates a new Client using the EOA's private key.
 func NewEOAClient(abiPath string) (*Client, error) {
-	contractAddressStr := appconfig.Get().ContractAddress
-	if contractAddressStr == "" {
-		log.Fatal("CONTRACT_ADDRESS is not set in environment variables.")
-	}
-	contractAddress := common.HexToAddress(contractAddressStr)
-
-	parsedABI, err := LoadContractABI(abiPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load contract ABI: %v", err)
-	}
-
 	privateKeyHex := appconfig.Get().EOAPrivateKey
 	if privateKeyHex == "" {
-		log.Fatal("EOA_PRIVATE_KEY is not set in the environment variables")
+		return nil, errors.New("EOA_PRIVATE_KEY is not set in environment variables")
 	}
-
-	privateKey, err := crypto.HexToECDSA(privateKeyHex)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode leader private key: %v", err)
-	}
-
-	return &Client{
-		ContractAddress: contractAddress,
-		PrivateKey:      privateKey,
-		ContractABI:     parsedABI,
-	}, nil
+	return NewClient(abiPath, privateKeyHex)
 }

--- a/utils/clients_test.go
+++ b/utils/clients_test.go
@@ -127,3 +127,203 @@ func TestLoadContractABI(t *testing.T) {
 		assert.Empty(t, parsedABI.Methods)
 	})
 }
+
+func TestNewClient(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "client_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a valid ABI file
+	validABI := map[string]interface{}{
+		"abi": []interface{}{
+			map[string]interface{}{
+				"type": "function",
+				"name": "testFunction",
+				"inputs": []interface{}{
+					map[string]interface{}{
+						"name": "param1",
+						"type": "uint256",
+					},
+				},
+				"outputs": []interface{}{},
+			},
+		},
+	}
+	abiBytes, err := json.Marshal(validABI)
+	require.NoError(t, err)
+
+	abiFile := filepath.Join(tempDir, "valid.json")
+	err = os.WriteFile(abiFile, abiBytes, 0644)
+	require.NoError(t, err)
+
+	// Valid private key (32 bytes hex without 0x prefix)
+	validPrivateKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	t.Run("success", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		defer os.Setenv("CONTRACT_ADDRESS", originalAddr)
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+
+		client, err := NewClient(abiFile, validPrivateKey)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, client.PrivateKey)
+		assert.NotNil(t, client.ContractABI)
+	})
+
+	t.Run("missing contract address", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		defer os.Setenv("CONTRACT_ADDRESS", originalAddr)
+
+		os.Setenv("CONTRACT_ADDRESS", "")
+
+		client, err := NewClient(abiFile, validPrivateKey)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "CONTRACT_ADDRESS is not set")
+	})
+
+	t.Run("empty private key", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		defer os.Setenv("CONTRACT_ADDRESS", originalAddr)
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+
+		client, err := NewClient(abiFile, "")
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "private key is not provided")
+	})
+
+	t.Run("invalid private key format", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		defer os.Setenv("CONTRACT_ADDRESS", originalAddr)
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+
+		client, err := NewClient(abiFile, "invalid-key")
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "failed to decode private key")
+	})
+
+	t.Run("ABI file not found", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		defer os.Setenv("CONTRACT_ADDRESS", originalAddr)
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+
+		client, err := NewClient("/nonexistent/path.json", validPrivateKey)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "failed to load contract ABI")
+	})
+}
+
+func TestNewLeaderClient(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "leader_client_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a valid ABI file
+	validABI := map[string]interface{}{
+		"abi": []interface{}{},
+	}
+	abiBytes, err := json.Marshal(validABI)
+	require.NoError(t, err)
+
+	abiFile := filepath.Join(tempDir, "valid.json")
+	err = os.WriteFile(abiFile, abiBytes, 0644)
+	require.NoError(t, err)
+
+	validPrivateKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	t.Run("success", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		originalKey := os.Getenv("LEADER_PRIVATE_KEY")
+		defer func() {
+			os.Setenv("CONTRACT_ADDRESS", originalAddr)
+			os.Setenv("LEADER_PRIVATE_KEY", originalKey)
+		}()
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+		os.Setenv("LEADER_PRIVATE_KEY", validPrivateKey)
+
+		client, err := NewLeaderClient(abiFile)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("missing leader private key", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		originalKey := os.Getenv("LEADER_PRIVATE_KEY")
+		defer func() {
+			os.Setenv("CONTRACT_ADDRESS", originalAddr)
+			os.Setenv("LEADER_PRIVATE_KEY", originalKey)
+		}()
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+		os.Setenv("LEADER_PRIVATE_KEY", "")
+
+		client, err := NewLeaderClient(abiFile)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "LEADER_PRIVATE_KEY is not set")
+	})
+}
+
+func TestNewEOAClient(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "eoa_client_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a valid ABI file
+	validABI := map[string]interface{}{
+		"abi": []interface{}{},
+	}
+	abiBytes, err := json.Marshal(validABI)
+	require.NoError(t, err)
+
+	abiFile := filepath.Join(tempDir, "valid.json")
+	err = os.WriteFile(abiFile, abiBytes, 0644)
+	require.NoError(t, err)
+
+	validPrivateKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	t.Run("success", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		originalKey := os.Getenv("EOA_PRIVATE_KEY")
+		defer func() {
+			os.Setenv("CONTRACT_ADDRESS", originalAddr)
+			os.Setenv("EOA_PRIVATE_KEY", originalKey)
+		}()
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+		os.Setenv("EOA_PRIVATE_KEY", validPrivateKey)
+
+		client, err := NewEOAClient(abiFile)
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("missing EOA private key", func(t *testing.T) {
+		originalAddr := os.Getenv("CONTRACT_ADDRESS")
+		originalKey := os.Getenv("EOA_PRIVATE_KEY")
+		defer func() {
+			os.Setenv("CONTRACT_ADDRESS", originalAddr)
+			os.Setenv("EOA_PRIVATE_KEY", originalKey)
+		}()
+
+		os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
+		os.Setenv("EOA_PRIVATE_KEY", "")
+
+		client, err := NewEOAClient(abiFile)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "EOA_PRIVATE_KEY is not set")
+	})
+}


### PR DESCRIPTION
  ## Summary                                                                                                                                             
  - Unify `NewLeaderClient` and `NewEOAClient` into a single `NewClient` function                                                                        
  - Replace `log.Fatal` with error returns for better testability                                                                                        
  - Add EstimateGas all servers fail test case for fallback RPC                                                                                          
                                                                                                                                                         
  ## Changes                                                                                                                                             
  - `utils/clients.go`: Refactor to use unified `NewClient` function                                                                                     
  - `utils/clients_test.go`: Add 15 test cases for NewClient, NewLeaderClient, NewEOAClient                                                              
  - `pkg/fallback_ethclient/fallback_rpc_test.go`: Add "all servers fail" test case                                                                      
  - `nodes/regular/handler_test.go`: Update error message assertion 