### PR TITLE
fix: prevent slow-send DoS attacks in stream handlers

### DIFF
--- a/nodes/leader/secret_value_handler_test.go
+++ b/nodes/leader/secret_value_handler_test.go
@@ -443,6 +443,7 @@ func TestAcceptSecretValueWhenHalted(t *testing.T) {
 	node.SetHalted(true)
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -456,6 +457,7 @@ func TestAcceptSecretValueInvalidJSON(t *testing.T) {
 
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader([]byte("invalid json"))
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -477,6 +479,7 @@ func TestAcceptSecretValueInvalidSignature(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -511,6 +514,7 @@ func TestAcceptSecretValueNoCOSFound(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -564,6 +568,7 @@ func TestAcceptSecretValueHashMismatch(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -622,6 +627,7 @@ func TestAcceptSecretValueSuccess(t *testing.T) {
 	})
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	// Cleanup
@@ -686,6 +692,7 @@ func TestAcceptSecretValueUpdateCommitError(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -785,6 +792,7 @@ func TestAcceptSecretValueSuccessfulSave(t *testing.T) {
 	})
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 	assert.False(t, updateCalled, "Update not yet called (test documents expected flow)")
 
@@ -837,6 +845,7 @@ func TestSetRoundSecretValueAfterSave(t *testing.T) {
 		Return(nil)
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	roundSecretBefore, _ := node.GetRoundSecretValue(uniqueKey, eoaAddressHex)
@@ -891,6 +900,7 @@ func TestAcceptSecretValueAppendToRoundSecrets(t *testing.T) {
 		Return(nil)
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	// Verify that secrets are appended to round secrets
@@ -956,6 +966,7 @@ func TestAcceptSecretValueSecretValueHexFormat(t *testing.T) {
 	})
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	actualHex := hex.EncodeToString(secretValue[:])
@@ -1019,6 +1030,7 @@ func TestAcceptSecretValueDatabaseSaveFlow(t *testing.T) {
 	})
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	assert.Equal(t, 0, updateCallCount, "Update call count before execution")
@@ -1085,6 +1097,7 @@ func TestAcceptSecretValueBroadcastPreparation(t *testing.T) {
 		Return(nil)
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	assert.Equal(t, [32]byte{}, savedSecretValue, "Secret value not yet saved")
@@ -1210,6 +1223,7 @@ func TestAcceptSecretValueStopsWhenUpdateFails(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	// Execute - should return early due to update failure
@@ -1275,6 +1289,7 @@ func TestSecretValueBroadcastLogging(t *testing.T) {
 	})
 
 	mockStream := new(MockStream)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	// Document the expected flow
@@ -1366,6 +1381,7 @@ func TestBroadcastCompletedBranch(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
@@ -1461,6 +1477,7 @@ func TestBroadcastIncompleteBranch(t *testing.T) {
 	reqBytes, _ := json.Marshal(req)
 	mockStream := new(MockStream)
 	mockStream.reader = bytes.NewReader(reqBytes)
+	mockStream.On("SetReadDeadline", mock.Anything).Return(nil)
 	mockStream.On("Close").Return(nil)
 	node.AcceptSecretValue(context.Background(), nil, mockStream, nil)
 

--- a/utils/streamHandler.go
+++ b/utils/streamHandler.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"strings"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -44,13 +47,30 @@ func CreateStream(ctx context.Context, h host.Host, nodeInfo NodeInfo, protocolS
 }
 
 func DecodeJSONWithContext(ctx context.Context, s network.Stream, v interface{}) error {
+	// Extract deadline from context or use default
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(10 * time.Second)
+	}
+
+	// CRITICAL FIX: Set read deadline on stream to prevent slow-send DoS attacks
+	// This ensures the underlying TCP read will timeout even if the sender is slow
+	if err := s.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("failed to set read deadline: %w", err)
+	}
+	defer s.SetReadDeadline(time.Time{}) // Clear deadline on exit
+
 	done := make(chan error, 1)
 	go func() {
 		err := json.NewDecoder(s).Decode(v)
 		done <- err
 	}()
+
 	select {
 	case err := <-done:
+		if err != nil && isDeadlineError(err) {
+			return fmt.Errorf("JSON decode timeout (stream deadline): %w", err)
+		}
 		return err
 
 	case <-ctx.Done():
@@ -60,4 +80,23 @@ func DecodeJSONWithContext(ctx context.Context, s network.Stream, v interface{})
 		}
 		return fmt.Errorf("JSON decode cancelled: %w", ctx.Err())
 	}
+}
+
+// isDeadlineError checks if an error is a deadline/timeout error from the network layer
+func isDeadlineError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for net.Error timeout
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// Check error message for common deadline-related strings
+	errStr := err.Error()
+	return strings.Contains(errStr, "deadline exceeded") ||
+		strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "timeout")
 }


### PR DESCRIPTION
## Summary

This PR fixes a slow-send DoS vulnerability in stream handlers where attackers could block goroutines indefinitely by sending JSON data very slowly (e.g., 1 byte per second).

### The Problem

The `DecodeJSONWithContext` function in `utils/streamHandler.go` used a context timeout to wrap the JSON decode operation, but **did not set a read deadline on the underlying stream**. This meant:

1. Attackers could open streams to `/cvs`, `/cos`, `/register`, `/secretValue`, `/acknowledgment`, etc.
2. Send JSON data extremely slowly (1 byte per second)
3. The goroutine reading from the stream would block indefinitely
4. With only ~8 malicious connections, an attacker could exhaust server resources

When the context timed out, `s.Reset()` was called, but this doesn't immediately terminate a blocking `Read()` operation on the stream.

### The Solution

Set a read deadline on the stream **before** starting the decode operation:

```go
// Extract deadline from context or use default (10 seconds)
deadline, ok := ctx.Deadline()
if !ok {
    deadline = time.Now().Add(10 * time.Second)
}

// CRITICAL FIX: Set read deadline on stream
if err := s.SetReadDeadline(deadline); err != nil {
    return fmt.Errorf("failed to set read deadline: %w", err)
}
defer s.SetReadDeadline(time.Time{}) // Clear deadline on exit
```

This ensures:
- The underlying TCP read will timeout when the deadline passes
- Any blocked `Read()` inside `json.Decoder` returns `os.ErrDeadlineExceeded`
- The goroutine unblocks and exits properly
- No goroutine leak, no resource exhaustion

### Protected Handlers

All 9 handlers that use `DecodeJSONWithContext` are now automatically protected:

| Handler | Protocol |
|---------|----------|
| handleCommitRequest | /cvs |
| handleCOSRequest | /cos |
| handleAcknowledgment | /acknowledgment |
| RegisterNode | /register |
| AcceptSecretValue | /secretValue |
| HandleCvs | /cvsBroadcast |
| HandleCos | /cosBroadcast |
| HandleSecret | /secretBroadcast |
| HandleSecretValueRequest | /sendSecretValue |

### Changes

- **`utils/streamHandler.go`**: Modified `DecodeJSONWithContext` to set stream read deadline; added `isDeadlineError()` helper function
- **`nodes/leader/secret_value_handler_test.go`**: Added `SetReadDeadline` mock expectations for testify/mock compatibility

## Test plan

- [x] Run `go test -v ./utils/...` - all tests pass
- [x] Run `go test -v ./nodes/leader/...` - handler tests pass
- [x] Run `go test -race -v ./utils/...` - no race conditions detected
- [ ] Manual verification: slow-send attack should now timeout properly