### PR TITLE
FIX: removed hardcoded 20s timeout in sendSecretValueRequestToNode (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ OFF_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR=20
 ON_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR=40
 ```
 
+> **Note:** `OFF_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR` also controls the timeout for waiting for secret value responses from regular nodes. Adjust this value based on your chain's block time (e.g., lower for fast chains like Arbitrum, higher for slower chains).
+
 
 ## Deployment
 

--- a/nodes/leader/reveal_requests.go
+++ b/nodes/leader/reveal_requests.go
@@ -96,18 +96,17 @@ func (n *LeaderNode) sendSecretValueRequestToNode(ctx context.Context, h host.Ho
 	} else {
 		log.Printf("✅ Secret value request sent to EOA %s for round %s with trail %s", regularEoa, round, trialNum)
 
-		// Start a timer to track if the response is received within 15 seconds
+		// timeout derived from contract period config (chain 	aware)
 		go func() {
-			timer := time.NewTimer(20 * time.Second)
+			timeoutSeconds := appconfig.GetContractPeriods().OffChainSubmissionPeriodPerOperator.Int64()
+			timer := time.NewTimer(time.Duration(timeoutSeconds) * time.Second)
 			defer timer.Stop()
 
-			// Wait for the timer to expire
 			<-timer.C
 
-			// If the timer expires and the secret value is not received, call handleMissingSecretValue
 			hasSecret, exists := n.GetRoundSecretValue(uniqueKey, regularEoa)
 			if !exists || !hasSecret {
-				log.Printf("Secret value not received for EOA %s in round %s with trail %s within 15 seconds. Handling missing secret value.", regularEoa, round, trialNum)
+				log.Printf("Secret value not received for EOA %s in round %s with trail %s within %d seconds. Handling missing secret value.", regularEoa, round, trialNum, timeoutSeconds)
 				n.SetSecretsOnChain(uniqueKey, true)
 				n.requestToSubmitS(ctx, round, trialNum)
 			}


### PR DESCRIPTION
  Fixes #64                                                                                                                                                                        
                                                                                                                                                                                   
  **Problem:**                                                                                                                                                                     
  Hardcoded 20-second timeout in `sendSecretValueRequestToNode` doesn't adapt to different chains (eth ~12s blocks, Polygon ~2s, arb ~0.25s).                            
                                                                                                                                                                                   
  **Solution:**                                                                                                                                                                    
  Use `OffChainSubmissionPeriodPerOperator` from contract config instead of hardcoded value.                                                                                       
                                                                                                                                                                                   
  **Why this approach:**                                                                                                                                                           
  - Already configured perchain by operators                                                                                                                                      
  - No extra RPC calls needed                                                                                                                                                      
  - No added latency or failure points                                                                                                                                             
                                                                                                                                                                                   
  **Why not dynamic block time fetching:**                                                                                                                                         
  - Would require 2-3 extra RPC calls per request                                                                                                                                  
  - Adds ~100-500ms latency waiting for RPC response                                                                                                                               
  - RPC could timeout/fail, breaking the flow                                                                                                                                      
  - More complex code for minimal benefit since operators already configure chain-specific params                                                                                  
                                                                                                                                                                                   
  **Changes:**                                                                                                                                                                     
  - `reveal_requests.go`: Use `OffChainSubmissionPeriodPerOperator.Int64()` instead of `20 * time.Second`                                                                          
  - `README.md`: Document that this param also controls secret value response timeout     
  
    *to test:**                                                                                                                                                                 
```bash                                                                                                                                                                          
  # Set custom timeout for your chain                                                                                                                                              
  export OFF_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR=10                                                                                                                               
                                                                                                                                                                                   
  # Run leader node - timeout will use 10s instead of hardcoded 20s