### PR TITLE
refactor: remove ChainID RPC call in favor of env config

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -227,3 +227,18 @@ func getEnvAsBigIntOrDefault(key string, defaultValue int64) *big.Int {
 	}
 	return parsed
 }
+
+// GetChainIDAsBigInt returns the ChainID from environment config as *big.Int.
+// Returns nil if CHAIN_ID is not set or invalid.
+func GetChainIDAsBigInt() *big.Int {
+	cfg := Get()
+	if cfg.ChainID == "" {
+		return nil
+	}
+	chainID := new(big.Int)
+	chainID, ok := chainID.SetString(cfg.ChainID, 10)
+	if !ok {
+		return nil
+	}
+	return chainID
+}

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -118,48 +118,9 @@ func ExecuteTransaction(
 
 	log.Infof("Preparing to execute %s...", functionName)
 
-	maxRetries := 3
-	retryDelay := 2 * time.Second
-	var chainID *big.Int
-	var chainIDErrors []error
-	var err error
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		chainID, err = fallbackEthClient.ChainID(ctx)
-		if err == nil {
-			if attempt > 1 {
-				log.Infof("Successfully fetched chain ID after %d retries for %s", attempt-1, functionName)
-			}
-			break
-		}
-
-		chainIDErrors = append(chainIDErrors, fmt.Errorf("attempt %d: %v", attempt, err))
-		log.Errorf("Failed to fetch chain ID for %s, attempt %d/%d: %v", functionName, attempt, maxRetries, err)
-
-		if attempt < maxRetries {
-			log.Printf("Waiting %v before retry %d/%d for ChainID", retryDelay, attempt+1, maxRetries)
-			select {
-			case <-ctx.Done():
-				errorDetails := fmt.Sprintf("failed to fetch chain ID after %d attempts for %s. Errors: ", attempt, functionName)
-				for i, e := range chainIDErrors {
-					if i > 0 {
-						errorDetails += "; "
-					}
-					errorDetails += fmt.Sprintf("Attempt %d: %v", i+1, e)
-				}
-				return nil, nil, errors.New(errorDetails)
-			case <-time.After(retryDelay):
-			}
-			continue
-		}
-		errorDetails := fmt.Sprintf("failed to fetch chain ID after %d attempts for %s. Errors: ", maxRetries, functionName)
-		for i, e := range chainIDErrors {
-			if i > 0 {
-				errorDetails += "; "
-			}
-			errorDetails += fmt.Sprintf("Attempt %d: %v", i+1, e)
-		}
-		return nil, nil, errors.New(errorDetails)
+	chainID := appconfig.GetChainIDAsBigInt()
+	if chainID == nil {
+		return nil, nil, fmt.Errorf("CHAIN_ID environment variable is not set or invalid")
 	}
 
 	auth, err := bind.NewKeyedTransactorWithChainID(client.PrivateKey, chainID)

--- a/eth/eth_test.go
+++ b/eth/eth_test.go
@@ -78,14 +78,6 @@ func (m *MockFallbackEthClient) SubscribeFilterLogs(ctx context.Context, q ether
 	return args.Get(0).(ethereum.Subscription), args.Error(1)
 }
 
-func (m *MockFallbackEthClient) ChainID(ctx context.Context) (*big.Int, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*big.Int), args.Error(1)
-}
-
 func (m *MockFallbackEthClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	args := m.Called(ctx, msg)
 	return args.Get(0).(uint64), args.Error(1)
@@ -350,6 +342,9 @@ func TestCallSmartContract_UnpackError(t *testing.T) {
 
 // Test ExecuteTransaction
 func TestExecuteTransaction_ChainIDError(t *testing.T) {
+	// Unset CHAIN_ID to test error handling
+	os.Unsetenv("CHAIN_ID")
+
 	mockClient := new(MockFallbackEthClient)
 	ctx := context.Background()
 
@@ -366,19 +361,17 @@ func TestExecuteTransaction_ChainIDError(t *testing.T) {
 		PrivateKey:      privateKey,
 	}
 
-	// ChainID should be called 3 times (maxRetries) before giving up
-	mockClient.On("ChainID", ctx).Return(nil, errors.New("chain ID error")).Times(3)
-
 	tx, auth, err := ExecuteTransaction(ctx, client, mockClient, "testMethod", big.NewInt(0))
 	assert.Error(t, err)
 	assert.Nil(t, tx)
 	assert.Nil(t, auth)
-	assert.Contains(t, err.Error(), "failed to fetch chain ID")
-
-	mockClient.AssertExpectations(t)
+	assert.Contains(t, err.Error(), "CHAIN_ID environment variable is not set or invalid")
 }
 
-func TestExecuteTransaction_PackError(t *testing.T) {
+func TestExecuteTransaction_NonceError(t *testing.T) {
+	os.Setenv("CHAIN_ID", "1337")
+	defer os.Unsetenv("CHAIN_ID")
+
 	mockClient := new(MockFallbackEthClient)
 	ctx := context.Background()
 
@@ -386,8 +379,43 @@ func TestExecuteTransaction_PackError(t *testing.T) {
 	require.NoError(t, err)
 
 	chainID := big.NewInt(1337)
-	mockClient.On("ChainID", ctx).Return(chainID, nil).Once()
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(t, err)
 
+	abiJSON := `[{"constant":false,"inputs":[],"name":"testMethod","outputs":[],"type":"function"}]`
+	parsedABI, err := abi.JSON(strings.NewReader(abiJSON))
+	require.NoError(t, err)
+
+	client := &utils.Client{
+		ContractABI:     parsedABI,
+		ContractAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		PrivateKey:      privateKey,
+	}
+	// SuggestGasTipCap and SuggestGasPrice are called before PendingNonceAt in sendWithRetry
+	mockClient.On("SuggestGasTipCap", ctx).Return(big.NewInt(1000000000), nil)
+	mockClient.On("SuggestGasPrice", ctx).Return(big.NewInt(1000000000), nil)
+	mockClient.On("PendingNonceAt", ctx, auth.From).Return(uint64(0), errors.New("nonce error"))
+
+	tx, auth, err := ExecuteTransaction(ctx, client, mockClient, "testMethod", big.NewInt(0))
+	assert.Error(t, err)
+	assert.Nil(t, tx)
+	assert.Nil(t, auth)
+	assert.Contains(t, err.Error(), "failed to get nonce")
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestExecuteTransaction_PackError(t *testing.T) {
+	os.Setenv("CHAIN_ID", "1337")
+	defer os.Unsetenv("CHAIN_ID")
+
+	mockClient := new(MockFallbackEthClient)
+	ctx := context.Background()
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	chainID := big.NewInt(1337)
 	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
 	require.NoError(t, err)
 
@@ -406,6 +434,56 @@ func TestExecuteTransaction_PackError(t *testing.T) {
 	assert.Nil(t, tx)
 	assert.Nil(t, auth)
 	assert.Contains(t, err.Error(), "failed to pack data")
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestExecuteTransaction_GasEstimationError(t *testing.T) {
+	os.Setenv("CHAIN_ID", "1337")
+	defer os.Unsetenv("CHAIN_ID")
+
+	mockClient := new(MockFallbackEthClient)
+	ctx := context.Background()
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	chainID := big.NewInt(1337)
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	require.NoError(t, err)
+
+	abiJSON := `[{"constant":false,"inputs":[],"name":"testMethod","outputs":[],"type":"function"}]`
+	parsedABI, err := abi.JSON(strings.NewReader(abiJSON))
+	require.NoError(t, err)
+
+	client := &utils.Client{
+		ContractABI:     parsedABI,
+		ContractAddress: common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		PrivateKey:      privateKey,
+	}
+	// SuggestGasTipCap and SuggestGasPrice are called before PendingNonceAt in sendWithRetry
+	mockClient.On("SuggestGasTipCap", ctx).Return(big.NewInt(1000000000), nil)
+	mockClient.On("SuggestGasPrice", ctx).Return(big.NewInt(1000000000), nil)
+	mockClient.On("PendingNonceAt", ctx, auth.From).Return(uint64(0), nil).Once()
+
+	packedData, err := client.ContractABI.Pack("testMethod")
+	require.NoError(t, err)
+
+	callMsg := ethereum.CallMsg{
+		From:  auth.From,
+		To:    &client.ContractAddress,
+		Data:  packedData,
+		Value: big.NewInt(0),
+	}
+
+	// Gas estimation fails 5 times (maxRetries in sendWithRetry)
+	mockClient.On("EstimateGas", ctx, callMsg).Return(uint64(0), errors.New("gas estimation failed")).Times(5)
+
+	tx, auth, err := ExecuteTransaction(ctx, client, mockClient, "testMethod", big.NewInt(0))
+	assert.Error(t, err)
+	assert.Nil(t, tx)
+	assert.Nil(t, auth)
+	assert.Contains(t, err.Error(), "failed to estimate gas after")
 
 	mockClient.AssertExpectations(t)
 }

--- a/nodes/leader/accept_commit.go
+++ b/nodes/leader/accept_commit.go
@@ -126,7 +126,7 @@ func (n *LeaderNode) processDeactivated(ctx context.Context, operator common.Add
 	var peerIDStr string
 	nodeInfos, err := n.nodeInfoRepository.GetNodeInfos(ctx)
 	if err != nil {
-		log.Printf("Database connection error while getting node infos for operator %s: %v", operator.Hex(), err)
+		return fmt.Errorf("failed to get node info, %v", err)
 	} else if len(nodeInfos) == 0 {
 		log.Printf("No node info found for operator %s.", operator.Hex())
 	} else {
@@ -136,8 +136,6 @@ func (n *LeaderNode) processDeactivated(ctx context.Context, operator common.Add
 				break
 			}
 		}
-	} else {
-		return fmt.Errorf("failed to get node info, %v", err)
 	}
 
 	if peerIDStr != "" {
@@ -187,10 +185,10 @@ func (n *LeaderNode) processSubmittedSecretRequest(ctx context.Context, round *b
 	if err != nil {
 		if err == pg.ErrNoRows {
 			log.Printf("Leader commit data not found for round %s, trial %s, EOA %s. Cannot process submitted secret.", n.GetSecretRequestSentForWhichRound(), trialNum.String(), regularNodeAddress.Hex())
-			return
+			return nil
 		}
 		log.Printf("Database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v", n.GetSecretRequestSentForWhichRound(), trialNum.String(), regularNodeAddress.Hex(), err)
-		return
+		return fmt.Errorf("failed to get leader commit data: %v", err)
 	}
 
 	// Update leader commit data with secretValue
@@ -691,12 +689,7 @@ func (n *LeaderNode) stopFailToSubmitCoMonitoring() {
 
 // Add function to call failToSubmitCo on chain
 func (n *LeaderNode) callFailToSubmitCo(ctx context.Context, round string, trialNum string) error {
-	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create leader client: %v", err)
-	}
-
-	_, _, err = n.ethService.ExecuteTransaction(
+	_, _, err := n.ethService.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,
@@ -810,12 +803,7 @@ func (n *LeaderNode) stopFailToSubmitCvMonitoring() {
 
 // Add function to call failToSubmitCv on chain
 func (n *LeaderNode) callFailToSubmitCv(ctx context.Context, round string, trialNum string) error {
-	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create leader client: %v", err)
-	}
-
-	_, _, err = n.ethService.ExecuteTransaction(
+	_, _, err := n.ethService.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,
@@ -1004,12 +992,7 @@ func (n *LeaderNode) callRequestToSubmitCv(ctx context.Context, round string, tr
 
 	packedIndices := PackIndices(indices)
 
-	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create leader client: %v", err)
-	}
-
-	_, _, err = n.ethService.ExecuteTransaction(
+	_, _, err := n.ethService.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,
@@ -1136,13 +1119,7 @@ func (n *LeaderNode) SubmitMerkleRoot(ctx context.Context, roundNum string, tria
 	var merkleRootBytes32 [32]byte
 	copy(merkleRootBytes32[:], merkleRoot)
 
-	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		n.SetSubmittingMerkleRoot(false) // Reset flag on failure
-		return fmt.Errorf("failed to create leader client: %v", err)
-	}
-
-	_, _, err = n.ethService.ExecuteTransaction(
+	_, _, err := n.ethService.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,

--- a/nodes/leader/accept_commit_test.go
+++ b/nodes/leader/accept_commit_test.go
@@ -3227,20 +3227,6 @@ func (m *MockFallbackEthClientForAcceptCommit) CallContract(ctx context.Context,
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (m *MockFallbackEthClientForAcceptCommit) ChainID(ctx context.Context) (*big.Int, error) {
-	for _, call := range m.ExpectedCalls {
-		if call.Method == "ChainID" {
-			args := m.Called(ctx)
-			if args.Get(0) == nil {
-				return nil, args.Error(1)
-			}
-			return args.Get(0).(*big.Int), args.Error(1)
-		}
-	}
-	// Default to mainnet chain ID when not explicitly mocked.
-	return big.NewInt(1), nil
-}
-
 func (m *MockFallbackEthClientForAcceptCommit) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	args := m.Called(ctx, msg)
 	return args.Get(0).(uint64), args.Error(1)

--- a/nodes/leader/reveal_requests_test.go
+++ b/nodes/leader/reveal_requests_test.go
@@ -68,14 +68,6 @@ func (m *MockFallbackEthClient) SubscribeFilterLogs(ctx context.Context, q ether
 	return args.Get(0).(ethereum.Subscription), args.Error(1)
 }
 
-func (m *MockFallbackEthClient) ChainID(ctx context.Context) (*big.Int, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*big.Int), args.Error(1)
-}
-
 func (m *MockFallbackEthClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	args := m.Called(ctx, msg)
 	return args.Get(0).(uint64), args.Error(1)
@@ -230,9 +222,6 @@ func (suite *RevealRequestsTestSuite) SetupTest() {
 	mockFallbackClient := new(MockFallbackEthClient)
 	mockFallbackClient.On("NetworkID", mock.Anything).Return(big.NewInt(1), nil).Maybe()
 	mockFallbackClient.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil).Maybe()
-	// ChainID is called by ExecuteTransaction when timers fire, so ensure it's always mocked
-	// Use Maybe() to allow multiple calls from different timers
-	mockFallbackClient.On("ChainID", mock.Anything).Return(big.NewInt(1), nil).Maybe()
 	mockFallbackClient.On("EstimateGas", mock.Anything, mock.Anything).Return(uint64(21000), nil).Maybe()
 	mockFallbackClient.On("SuggestGasPrice", mock.Anything).Return(big.NewInt(1000000000), nil).Maybe()
 	mockFallbackClient.On("SuggestGasTipCap", mock.Anything).Return(big.NewInt(1000000000), nil).Maybe()

--- a/nodes/regular/handler_test.go
+++ b/nodes/regular/handler_test.go
@@ -396,14 +396,6 @@ func (m *MockFallbackEthClient) SubscribeFilterLogs(ctx context.Context, q ether
 	return args.Get(0).(ethereum.Subscription), args.Error(1)
 }
 
-func (m *MockFallbackEthClient) ChainID(ctx context.Context) (*big.Int, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*big.Int), args.Error(1)
-}
-
 func (m *MockFallbackEthClient) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	args := m.Called(ctx, msg)
 	return args.Get(0).(uint64), args.Error(1)

--- a/nodes/regular/send_commit.go
+++ b/nodes/regular/send_commit.go
@@ -257,11 +257,6 @@ func (n *RegularNode) submitS(ctx context.Context, round string, trialNum string
 
 	fmt.Printf("Extracted secret_value as bytes32: %x\n", secretValueBytes)
 
-	clientUtils, err := utils.NewEOAClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("Failed to create EOA client: %v", err)
-	}
-
 	_, _, err = eth.Service.ExecuteTransaction(
 		ctx,
 		n.client,
@@ -666,12 +661,7 @@ func (n *RegularNode) ResetMonitoringState(round string, trialNum string) {
 
 // callFailToRequestSubmitCVOrSubmitMerkleRoot calls the contract function to fail the leader
 func (n *RegularNode) callFailToRequestSubmitCVOrSubmitMerkleRoot(ctx context.Context, round string, trialNum string) error {
-	clientUtils, err := utils.NewEOAClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create EOA client: %v", err)
-	}
-
-	_, _, err = eth.Service.ExecuteTransaction(
+	_, _, err := eth.Service.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,
@@ -750,12 +740,7 @@ func (n *RegularNode) StopFailToSubmitMerkleRootAfterDisputeMonitoring(round str
 
 // callFailToSubmitMerkleRootAfterDispute calls the contract function to fail the leader for not submitting merkle root
 func (n *RegularNode) callFailToSubmitMerkleRootAfterDispute(ctx context.Context, round string, trialNum string) error {
-	clientUtils, err := utils.NewEOAClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create EOA client: %v", err)
-	}
-
-	_, _, err = eth.Service.ExecuteTransaction(
+	_, _, err := eth.Service.ExecuteTransaction(
 		ctx,
 		n.client,
 		n.fallbackEthClient,
@@ -871,11 +856,6 @@ func (n *RegularNode) StopRequestToSubmitSOrGenerateRandomNumberMonitoring(round
 // callFailToRequestSOrGenerateRandomNumber calls the contract function to fail
 func (n *RegularNode) callFailToRequestSOrGenerateRandomNumber(ctx context.Context, round string, trialNum string) error {
 	log.Printf("Calling failToRequestSOrGenerateRandomNumber for round %s with trial %s", round, trialNum)
-
-	clientUtils, err := utils.NewEOAClient("contract/abi/Commit2RevealDRB.json")
-	if err != nil {
-		return fmt.Errorf("failed to create EOA client: %v", err)
-	}
 
 	// Execute the transaction
 	_, _, err := eth.Service.ExecuteTransaction(

--- a/pkg/fallback_ethclient/fallback_rpc.go
+++ b/pkg/fallback_ethclient/fallback_rpc.go
@@ -242,21 +242,6 @@ func (f *FallbackRPCClient) EstimateGas(ctx context.Context, msg ethereum.CallMs
 	return 0, lastErr
 }
 
-func (f *FallbackRPCClient) ChainID(ctx context.Context) (*big.Int, error) {
-	var lastErr error
-	for i := 0; i < len(f.clients); i++ {
-		client := f.getCurrentClient()
-		id, err := client.ChainID(ctx)
-		if err == nil {
-			return id, nil
-		}
-		lastErr = err
-		f.logger.WithError(err).Warn("RPC get chain ID failed, switching to fallback")
-		f.switchToNextClient()
-	}
-	return nil, fmt.Errorf("all RPCs failed: %v", lastErr)
-}
-
 // SubscribeFilterLogs implements the ethereum.ContractTransactor interface
 func (f *FallbackRPCClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
 	var lastErr error

--- a/pkg/fallback_ethclient/fallback_rpc_test.go
+++ b/pkg/fallback_ethclient/fallback_rpc_test.go
@@ -838,83 +838,6 @@ func TestFallbackRPCClient_EstimateGas(t *testing.T) {
 	})
 }
 
-func TestFallbackRPCClient_ChainID(t *testing.T) {
-	logger.InitLogger()
-
-	t.Run("success on first client", func(t *testing.T) {
-		server := createMockRPCServer(t, func(req *jsonRPCRequest) *jsonRPCResponse {
-			if req.Method == "eth_chainId" {
-				return &jsonRPCResponse{
-					JSONRPC: "2.0",
-					Result:  "0x1",
-					ID:      req.ID,
-				}
-			}
-			return &jsonRPCResponse{JSONRPC: "2.0", Result: "0x1", ID: req.ID}
-		})
-		defer server.Close()
-
-		client, err := NewFallbackRPCClient([]string{server.URL})
-		require.NoError(t, err)
-		defer client.Close()
-
-		chainID, err := client.ChainID(context.Background())
-		require.NoError(t, err)
-		assert.NotNil(t, chainID)
-	})
-
-	t.Run("success after fallback", func(t *testing.T) {
-		chainIdCallCount := 0
-		server1 := createMockRPCServer(t, func(req *jsonRPCRequest) *jsonRPCResponse {
-			if req.Method == "eth_chainId" {
-				chainIdCallCount++
-				// Allow first 2 calls to succeed (during Dial and any initial setup)
-				// Dial might make 1-2 calls to verify connection
-				// After that, fail on subsequent calls (which will be our test call)
-				if chainIdCallCount <= 2 {
-					return &jsonRPCResponse{
-						JSONRPC: "2.0",
-						Result:  "0x1",
-						ID:      req.ID,
-					}
-				}
-				// Fail on the 3rd call and beyond (our test call)
-				return &jsonRPCResponse{
-					JSONRPC: "2.0",
-					Error: &rpcError{
-						Code:    -32000,
-						Message: "network error",
-					},
-					ID: req.ID,
-				}
-			}
-			return &jsonRPCResponse{JSONRPC: "2.0", Result: "0x1", ID: req.ID}
-		})
-		defer server1.Close()
-
-		server2 := createMockRPCServer(t, func(req *jsonRPCRequest) *jsonRPCResponse {
-			if req.Method == "eth_chainId" {
-				return &jsonRPCResponse{
-					JSONRPC: "2.0",
-					Result:  "0x1",
-					ID:      req.ID,
-				}
-			}
-			return &jsonRPCResponse{JSONRPC: "2.0", Result: "0x1", ID: req.ID}
-		})
-		defer server2.Close()
-
-		client, err := NewFallbackRPCClient([]string{server1.URL, server2.URL})
-		require.NoError(t, err)
-		defer client.Close()
-
-		// Now when we call ChainID, server1 should fail (3rd call) and fallback to server2
-		chainID, err := client.ChainID(context.Background())
-		require.NoError(t, err)
-		assert.NotNil(t, chainID)
-	})
-}
-
 func TestFallbackRPCClient_BalanceAt(t *testing.T) {
 	logger.InitLogger()
 
@@ -1298,15 +1221,6 @@ func TestFallbackRPCClient_AllClientsExhausted(t *testing.T) {
 
 	// Mark test as started - now subsequent calls should fail
 	testStarted = true
-
-	// All clients should be tried
-	_, err = client.ChainID(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "all RPCs failed")
-	// Each server should have been called at least once for eth_chainId during the test
-	assert.Greater(t, chainIdCallCounts["server1"], 0, "server1 should be called")
-	assert.Greater(t, chainIdCallCounts["server2"], 0, "server2 should be called")
-	assert.Greater(t, chainIdCallCounts["server3"], 0, "server3 should be called")
 }
 
 // TestFallbackRPCClient_ConcurrentAccess tests concurrent access to the client

--- a/pkg/fallback_ethclient/interfaces.go
+++ b/pkg/fallback_ethclient/interfaces.go
@@ -15,7 +15,6 @@ type IFallbackEthClient interface {
 	SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error)
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error)
-	ChainID(ctx context.Context) (*big.Int, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)


### PR DESCRIPTION
This change removes the RPC call for `ChainID` and replaces it with a value set in an environment variable. `ChainID` is a fixed value, and even though it's set in the `.env` file, this improves the inefficient code that retrieves the value via RPC on every request.