### PR TITLE
fix: distinguish between not-found and actual errors in database, improve error handling

### DIFF
--- a/commit-reveal2/commit_test.go
+++ b/commit-reveal2/commit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/tokamak-network/DRB-node/database"
@@ -1295,7 +1296,7 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 	t.Run("hash with maximum values", func(t *testing.T) {
 		eth.Service = mockService
 
-		maxRound := "9223372036854775807" 
+		maxRound := "9223372036854775807"
 		veryLargeRound := "999999999999999999999999999999999999999999999999999999999999999999999"
 
 		secretValue1, cos1, cvs1, err1 := GenerateCommit(maxRound, operator)
@@ -1304,7 +1305,6 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 		secretValue2, cos2, cvs2, err2 := GenerateCommit(veryLargeRound, operator)
 		assert.NoError(t, err2)
 
-	
 		assert.Len(t, secretValue1, 32)
 		assert.Len(t, cos1, 32)
 		assert.Len(t, cvs1, 32)
@@ -1324,7 +1324,6 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 			secretValue, cos, cvs, err := GenerateCommit(testRound, operator)
 			assert.NoError(t, err)
 
-
 			assert.Len(t, secretValue, 32, "Secret value must be exactly 32 bytes for round %s", testRound)
 			assert.Len(t, cos, 32, "COS must be exactly 32 bytes for round %s", testRound)
 			assert.Len(t, cvs, 32, "CVS must be exactly 32 bytes for round %s", testRound)
@@ -1339,7 +1338,7 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 		eth.Service = mockService
 
 		round1 := "100"
-		round2 := "101" 
+		round2 := "101"
 
 		secretValue1, cos1, cvs1, err1 := GenerateCommit(round1, operator)
 		assert.NoError(t, err1)
@@ -1363,7 +1362,7 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 	})
 
 	t.Run("hash with special byte patterns", func(t *testing.T) {
-		allZerosAddr := common.Address{} 
+		allZerosAddr := common.Address{}
 		allFFAddr := common.BytesToAddress([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
 		// Alternating pattern
@@ -1387,13 +1386,11 @@ func TestGenerateCommit_CryptographicProperties(t *testing.T) {
 		}
 		eth.Service = specialMockService
 
-
 		results := make(map[string][32]byte)
 		for i, op := range specialOperators {
 			secretValue, cos, cvs, err := GenerateCommit("42", op.Hex())
 			assert.NoError(t, err, "Should handle special pattern operator at index %d", i)
 
-		
 			assert.Len(t, secretValue, 32)
 			assert.Len(t, secretValue, 32)
 			assert.Len(t, cos, 32)
@@ -1516,7 +1513,8 @@ func (m *MockEthServiceForGenerateCommit) GetActivatedOperatorsUnsafe() []common
 func (m *MockEthServiceForGenerateCommit) GetActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) ([]common.Address, error) {
 	return nil, nil
 }
-func (m *MockEthServiceForGenerateCommit) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *MockEthServiceForGenerateCommit) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
+	return nil
 }
 func (m *MockEthServiceForGenerateCommit) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {
 	return nil, nil
@@ -1580,7 +1578,7 @@ func TestDetermineRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		activatedOps := []common.Address{}
 		result, err := service.DetermineRevealOrder(ctx, roundNum, trialNum, activatedOps)
@@ -1598,12 +1596,12 @@ func TestDetermineRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
 
-		mockLeaderCommitRepo.On("GetLeaderCommitByRoundAndEoaAddr", ctx, roundNum, trialNum, operator.Hex()).Return(nil, errors.New("commit not found"))
+		mockLeaderCommitRepo.On("GetLeaderCommitByRoundAndEoaAddr", ctx, roundNum, trialNum, operator.Hex()).Return(nil, pg.ErrNoRows)
 
 		result, err := service.DetermineRevealOrder(ctx, roundNum, trialNum, activatedOps)
 
@@ -1621,7 +1619,7 @@ func TestDetermineRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
@@ -1647,7 +1645,7 @@ func TestDetermineRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
@@ -1675,7 +1673,7 @@ func TestDetermineRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operators := []common.Address{
 			common.HexToAddress("0x1234567890123456789012345678901234567890"),
@@ -1739,7 +1737,7 @@ func TestDetermineRegularRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		activatedOps := []common.Address{}
 		result, err := service.DetermineRegularRevealOrder(ctx, roundNum, trialNum, activatedOps)
@@ -1757,12 +1755,12 @@ func TestDetermineRegularRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
 
-		mockPeerCommitRepo.On("GetPeerCommitData", ctx, roundNum, trialNum, operator.Hex()).Return(nil, errors.New("commit not found"))
+		mockPeerCommitRepo.On("GetPeerCommitData", ctx, roundNum, trialNum, operator.Hex()).Return(nil, pg.ErrNoRows)
 
 		result, err := service.DetermineRegularRevealOrder(ctx, roundNum, trialNum, activatedOps)
 
@@ -1780,7 +1778,7 @@ func TestDetermineRegularRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
@@ -1806,7 +1804,7 @@ func TestDetermineRegularRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operator := common.HexToAddress("0x1234567890123456789012345678901234567890")
 		activatedOps := []common.Address{operator}
@@ -1834,7 +1832,7 @@ func TestDetermineRegularRevealOrder(t *testing.T) {
 
 		service := NewRevealOrderService(mockRevealOrderRepo, mockPeerCommitRepo, mockLeaderCommitRepo)
 
-		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, errors.New("not found"))
+		mockRevealOrderRepo.On("GetRevealOrder", ctx, roundNum, trialNum).Return(nil, pg.ErrNoRows)
 
 		operators := []common.Address{
 			common.HexToAddress("0x1234567890123456789012345678901234567890"),

--- a/commit-reveal2/reveal_order.go
+++ b/commit-reveal2/reveal_order.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-pg/pg/v10"
 	"github.com/tokamak-network/DRB-node/database"
 	"github.com/tokamak-network/DRB-node/utils"
 )
@@ -90,7 +91,10 @@ func (s *RevealOrderService) determineOrder(rv [32]byte, cvsValues [][]byte) []i
 func (s *RevealOrderService) extractLeaderCommitData(ctx context.Context, roundNum, trialNum, eoaAddressStr string) ([]byte, []byte, error) {
 	commitData, err := s.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, roundNum, trialNum, eoaAddressStr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load leader commit for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
+		if err == pg.ErrNoRows {
+			return nil, nil, fmt.Errorf("leader commit data not found for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
+		}
+		return nil, nil, fmt.Errorf("database connection error while loading leader commit for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
 	}
 
 	if commitData.Cos == [32]byte{} {
@@ -104,7 +108,10 @@ func (s *RevealOrderService) extractLeaderCommitData(ctx context.Context, roundN
 func (s *RevealOrderService) extractPeerCommitData(ctx context.Context, roundNum, trialNum, eoaAddressStr string) ([]byte, []byte, error) {
 	commitData, err := s.peerCommitRepository.GetPeerCommitData(ctx, roundNum, trialNum, eoaAddressStr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load peer commit for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
+		if err == pg.ErrNoRows {
+			return nil, nil, fmt.Errorf("peer commit data not found for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
+		}
+		return nil, nil, fmt.Errorf("database connection error while loading peer commit for operator %s in round %s with trial %s: %w", eoaAddressStr, roundNum, trialNum, err)
 	}
 
 	if utils.ConvertByteArray(commitData.Cos) == [32]byte{} {

--- a/database/broadcast_tracker_test.go
+++ b/database/broadcast_tracker_test.go
@@ -316,8 +316,11 @@ func TestBroadcastTrackerRepository_GetBroadcastTrackers_ErrorHandling(t *testin
 	assert.NoError(t, err, "Failed to drop table for test")
 
 	// Try to get trackers - should get an error because table doesn't exist
-	_, err = repo.GetBroadcastTrackers(ctx)
+	// Should return empty slice on error (not nil)
+	trackers, err := repo.GetBroadcastTrackers(ctx)
 	assert.Error(t, err, "Expected error when table is missing")
+	assert.NotNil(t, trackers, "Should return non-nil slice")
+	assert.Equal(t, 0, len(trackers), "Should return empty slice on error")
 
 	// Restore the schema
 	dsn := "postgres://postgres:123@localhost:5433/testdb?sslmode=disable"
@@ -555,8 +558,11 @@ func TestBroadcastTrackerRepository_GetBroadcastTrackers_ContextTimeout(t *testi
 	repo := NewBroadcastTrackerRepository(GetDB())
 
 	// This call should block on the locked table and time out
-	_, err = repo.GetBroadcastTrackers(ctx)
+	// Should return empty slice on error (not nil)
+	trackers, err := repo.GetBroadcastTrackers(ctx)
 	assert.Error(t, err, "Expected an error due to context timeout")
+	assert.NotNil(t, trackers, "Should return non-nil slice")
+	assert.Equal(t, 0, len(trackers), "Should return empty slice on error")
 	assert.Contains(t, err.Error(), "i/o timeout", "Error should be related to i/o timeout")
 }
 

--- a/database/leader_commit_test.go
+++ b/database/leader_commit_test.go
@@ -411,8 +411,11 @@ func TestLeaderCommitRepository_GetByRoundAndTrialNum_ErrorHandling(t *testing.T
 	assert.NoError(t, err, "Failed to drop table for test")
 
 	// Try to get commits - should get an error because table doesn't exist
-	_, err = repo.GetLeaderCommitsByRoundAndTrialNum(ctx, "test_round", "test_trial")
+	// Should return empty slice on error (not nil)
+	leaderCommits, err := repo.GetLeaderCommitsByRoundAndTrialNum(ctx, "test_round", "test_trial")
 	assert.Error(t, err, "Expected error when table is missing")
+	assert.NotNil(t, leaderCommits, "Should return non-nil slice")
+	assert.Equal(t, 0, len(leaderCommits), "Should return empty slice on error")
 
 	// Restore the schema
 	dsn := "postgres://postgres:123@localhost:5433/testdb?sslmode=disable"

--- a/database/node_info_test.go
+++ b/database/node_info_test.go
@@ -248,8 +248,11 @@ func TestNodeInfoRepository_GetNodeInfos_ErrorHandling(t *testing.T) {
 	assert.NoError(t, err, "Failed to drop table for test")
 
 	// Try to get node infos - should get an error because table doesn't exist
-	_, err = repo.GetNodeInfos(ctx)
+	// Should return empty slice on error (not nil)
+	nodeInfos, err := repo.GetNodeInfos(ctx)
 	assert.Error(t, err, "Expected error when table is missing")
+	assert.NotNil(t, nodeInfos, "Should return non-nil slice")
+	assert.Equal(t, 0, len(nodeInfos), "Should return empty slice on error")
 
 	// Restore the schema
 	dsn := "postgres://postgres:123@localhost:5433/testdb?sslmode=disable"
@@ -775,8 +778,11 @@ func TestNodeInfoRepository_GetNodeInfos_ContextTimeout(t *testing.T) {
 	repo := NewNodeInfoRepository(GetDB())
 
 	// This call should block on the locked table and time out
-	_, err = repo.GetNodeInfos(ctx)
+	// Should return empty slice on error (not nil)
+	nodeInfos, err := repo.GetNodeInfos(ctx)
 	assert.Error(t, err, "Expected an error due to context timeout")
+	assert.NotNil(t, nodeInfos, "Should return non-nil slice")
+	assert.Equal(t, 0, len(nodeInfos), "Should return empty slice on error")
 	// The error can be either "context deadline exceeded" or "i/o timeout" depending on the driver
 	assert.True(t, strings.Contains(err.Error(), "context deadline exceeded") ||
 		strings.Contains(err.Error(), "i/o timeout"),

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -485,13 +485,14 @@ func GetActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethcl
 	return activatedOperators, nil
 }
 
-func UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
 	operators, err := GetActivatedOperators(ctx, fallbackEthClient)
 	if err != nil {
 		log.Printf("Error updating ActivatedOperators: %v", err)
-		return
+		return err
 	}
 	SetActivatedOperatorsCached(operators)
+	return nil
 }
 
 // UpdateCurrentRoundFromContract fetches the current round from the contract

--- a/eth/interface.go
+++ b/eth/interface.go
@@ -21,7 +21,7 @@ type IEthService interface {
 	SetActivatedOperatorsCached(operators []common.Address)
 	GetActivatedOperatorsUnsafe() []common.Address
 	GetActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) ([]common.Address, error)
-	UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient)
+	UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error
 
 	// Contract interactions
 	CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error)
@@ -57,8 +57,8 @@ func (s *DefaultEthService) GetActivatedOperators(ctx context.Context, fallbackE
 	return GetActivatedOperators(ctx, fallbackEthClient)
 }
 
-func (s *DefaultEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
-	UpdateActivatedOperators(ctx, fallbackEthClient)
+func (s *DefaultEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
+	return UpdateActivatedOperators(ctx, fallbackEthClient)
 }
 
 func (s *DefaultEthService) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {

--- a/libp2putils/libp2p_client.go
+++ b/libp2putils/libp2p_client.go
@@ -55,10 +55,10 @@ func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID
 			keyFileName = fmt.Sprintf("regularnode%s.bin", cfg.RegularNodeNumber)
 		}
 	} else if nodeType == "leader" {
-        keyFileName = "leadernode.bin"
-    } else {
-        return nil, "", fmt.Errorf("invalid nodeType: %s. nodeType must be 'leader' or 'regular'", nodeType)
-    }
+		keyFileName = "leadernode.bin"
+	} else {
+		return nil, "", fmt.Errorf("invalid nodeType: %s. nodeType must be 'leader' or 'regular'", nodeType)
+	}
 
 	filePath := fmt.Sprintf("static-key/%s", keyFileName)
 
@@ -160,7 +160,11 @@ func (p *P2PClient) ConnectToPeer(ctx context.Context, leaderIP, leaderPort, lea
 func (p *P2PClient) GetConnectedPeers(ctx context.Context) map[string]NodeInfo {
 	nodes, err := p.nodeInfoRepository.GetNodeInfos(ctx)
 	if err != nil {
-		log.Printf("Failed to get node infos: %v", err)
+		log.Printf("Database connection error while getting node infos: %v", err)
+		return nil
+	}
+	if len(nodes) == 0 {
+		log.Printf("No node infos found.")
 		return nil
 	}
 

--- a/nodes/leader/accept_commit.go
+++ b/nodes/leader/accept_commit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/go-pg/pg/v10"
 	"github.com/libp2p/go-libp2p/core/peer"
 	commitreveal2 "github.com/tokamak-network/DRB-node/commit-reveal2"
 	appconfig "github.com/tokamak-network/DRB-node/config"
@@ -314,11 +315,17 @@ func (n *LeaderNode) receiveCommit(ctx context.Context) {
 
 func (n *LeaderNode) processDeactivated(ctx context.Context, operator common.Address) {
 	fmt.Printf("Deactivated Event:\n Operator %v\n", operator)
-	eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient)
+	if err := eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient); err != nil {
+		log.Printf("Failed to update activated operators after deactivation: %v", err)
+	}
 
 	var peerIDStr string
 	nodeInfos, err := n.nodeInfoRepository.GetNodeInfos(ctx)
-	if err == nil {
+	if err != nil {
+		log.Printf("Database connection error while getting node infos for operator %s: %v", operator.Hex(), err)
+	} else if len(nodeInfos) == 0 {
+		log.Printf("No node info found for operator %s.", operator.Hex())
+	} else {
 		for _, nodeInfo := range nodeInfos {
 			if nodeInfo.EOAAddress == operator.Hex() {
 				peerIDStr = nodeInfo.PeerID
@@ -372,7 +379,11 @@ func (n *LeaderNode) processSubmittedSecretRequest(ctx context.Context, round *b
 	fmt.Println("GetSecretRequestSentForWhichRound", n.GetSecretRequestSentForWhichRound())
 	leaderCommits, err := n.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, n.GetSecretRequestSentForWhichRound(), trialNum.String(), regularNodeAddress.Hex())
 	if err != nil {
-		log.Printf("Failed to get leadercommit data from database by round and eoaAddress %v", err)
+		if err == pg.ErrNoRows {
+			log.Printf("Leader commit data not found for round %s, trial %s, EOA %s. Cannot process submitted secret.", n.GetSecretRequestSentForWhichRound(), trialNum.String(), regularNodeAddress.Hex())
+			return
+		}
+		log.Printf("Database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v", n.GetSecretRequestSentForWhichRound(), trialNum.String(), regularNodeAddress.Hex(), err)
 		return
 	}
 
@@ -384,6 +395,7 @@ func (n *LeaderNode) processSubmittedSecretRequest(ctx context.Context, round *b
 	err = n.leaderCommitRepository.UpdateLeaderCommit(ctx, leaderCommits)
 	if err != nil {
 		log.Printf("Failed to save updated leader commits: %v", err)
+		return
 	}
 
 	// Broadcast the secret value to all activated regular nodes
@@ -420,7 +432,9 @@ func (n *LeaderNode) processRandomRequestNumber(ctx context.Context, blockTimest
 		fmt.Printf("Status Event:\n StartTime: %v\n State: %v\n Round: %v\n",
 			blockTimestamp, state, round)
 		// Update the activated operators
-		n.ethService.UpdateActivatedOperators(ctx, n.fallbackEthClient)
+		if err := n.ethService.UpdateActivatedOperators(ctx, n.fallbackEthClient); err != nil {
+			log.Printf("Failed to update activated operators for new round: %v", err)
+		}
 		// Reset the indices for the new round
 		n.ResetIndicesForNewRound()
 		log.Printf("Reset Indices array for new round %s with trail %s", n.GetCurrentRound(), n.GetCurrentTrial())
@@ -452,7 +466,10 @@ func (n *LeaderNode) processRandomRequestNumber(ctx context.Context, blockTimest
 		// Set Halted to 1 to halt the round
 		n.SetHalted(true)
 		// Delete round and trial data from database
-		n.batchRepository.DeleteRoundTrialDataForLeaderNode(ctx, n.GetCurrentRound(), n.GetCurrentTrial())
+		err := n.batchRepository.DeleteRoundTrialDataForLeaderNode(ctx, n.GetCurrentRound(), n.GetCurrentTrial())
+		if err != nil {
+			log.Printf("Error deleting the trial and round data for the leader node")
+		}
 
 		// resume the round
 		n.resuming(ctx)
@@ -565,30 +582,37 @@ func (n *LeaderNode) processCOS(ctx context.Context, round *big.Int, trialNum *b
 
 	leaderCommitData, err := n.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, roundStr, trialNumStr, eoa.Hex())
 	if err != nil {
-		signInfo := utils.SignInfo{
-			R: "",
-			S: "",
-			V: "",
-		}
-		leaderCommit := utils.LeaderCommitData{
-			UniqueKey:             uniqueKey,
-			Round:                 roundStr,
-			TrialNum:              trialNumStr,
-			EOAAddress:            eoa.Hex(),
-			Cvs:                   [32]byte{},
-			CvsHex:                "",
-			Cos:                   [32]byte{},
-			CosHex:                "",
-			SecretValue:           [32]byte{},
-			SecretValueHex:        "",
-			Sign:                  signInfo,
-			SubmitMerkleRootDone:  false,
-			RandomNumberGenerated: false,
-			CreatedAt:             time.Now().Unix(),
-		}
-		err := n.leaderCommitRepository.AddLeaderCommit(ctx, &leaderCommit)
-		if err != nil {
-			return fmt.Errorf("failed to add leader commit for round %s, trial %s, EOA %s: %v",
+		if err == pg.ErrNoRows {
+			// Leader commit data not found, create new entry with COS value
+			signInfo := utils.SignInfo{
+				R: "",
+				S: "",
+				V: "",
+			}
+			leaderCommit := utils.LeaderCommitData{
+				UniqueKey:             uniqueKey,
+				Round:                 roundStr,
+				TrialNum:              trialNumStr,
+				EOAAddress:            eoa.Hex(),
+				Cvs:                   [32]byte{},
+				CvsHex:                "",
+				Cos:                   [32]byte{},
+				CosHex:                "",
+				SecretValue:           [32]byte{},
+				SecretValueHex:        "",
+				Sign:                  signInfo,
+				SubmitMerkleRootDone:  false,
+				RandomNumberGenerated: false,
+				CreatedAt:             time.Now().Unix(),
+			}
+			err := n.leaderCommitRepository.AddLeaderCommit(ctx, &leaderCommit)
+			if err != nil {
+				return fmt.Errorf("failed to add leader commit for round %s, trial %s, EOA %s: %v",
+					roundStr, trialNumStr, eoa.Hex(), err)
+			}
+		} else {
+			log.Printf("Database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v", roundStr, trialNumStr, eoa.Hex(), err)
+			return fmt.Errorf("database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v",
 				roundStr, trialNumStr, eoa.Hex(), err)
 		}
 	} else {
@@ -661,30 +685,37 @@ func (n *LeaderNode) processCVS(ctx context.Context, round *big.Int, trialNum *b
 	uniqueKey := utils.GetUniqueKey(roundStr, trialNumStr)
 	leaderCommitData, err := n.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, roundStr, trialNumStr, eoa.Hex())
 	if err != nil {
-		signInfo := utils.SignInfo{
-			R: "",
-			S: "",
-			V: "",
-		}
-		leaderCommit := utils.LeaderCommitData{
-			UniqueKey:             uniqueKey,
-			Round:                 roundStr,
-			TrialNum:              trialNumStr,
-			EOAAddress:            eoa.Hex(),
-			Cvs:                   cvs,
-			CvsHex:                cvsHex,
-			Cos:                   [32]byte{},
-			CosHex:                "",
-			SecretValue:           [32]byte{},
-			SecretValueHex:        "",
-			Sign:                  signInfo,
-			SubmitMerkleRootDone:  false,
-			RandomNumberGenerated: false,
-			CreatedAt:             time.Now().Unix(),
-		}
-		err := n.leaderCommitRepository.AddLeaderCommit(ctx, &leaderCommit)
-		if err != nil {
-			return fmt.Errorf("failed to add leader commit for round %s, trial %s, EOA %s: %v",
+		if err == pg.ErrNoRows {
+			// Leader commit data not found, create new entry with CVS value
+			signInfo := utils.SignInfo{
+				R: "",
+				S: "",
+				V: "",
+			}
+			leaderCommit := utils.LeaderCommitData{
+				UniqueKey:             uniqueKey,
+				Round:                 roundStr,
+				TrialNum:              trialNumStr,
+				EOAAddress:            eoa.Hex(),
+				Cvs:                   cvs,
+				CvsHex:                cvsHex,
+				Cos:                   [32]byte{},
+				CosHex:                "",
+				SecretValue:           [32]byte{},
+				SecretValueHex:        "",
+				Sign:                  signInfo,
+				SubmitMerkleRootDone:  false,
+				RandomNumberGenerated: false,
+				CreatedAt:             time.Now().Unix(),
+			}
+			err := n.leaderCommitRepository.AddLeaderCommit(ctx, &leaderCommit)
+			if err != nil {
+				return fmt.Errorf("failed to add leader commit for round %s, trial %s, EOA %s: %v",
+					roundStr, trialNumStr, eoa.Hex(), err)
+			}
+		} else {
+			log.Printf("Database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v", roundStr, trialNumStr, eoa.Hex(), err)
+			return fmt.Errorf("database connection error while getting leader commit data for round %s, trial %s, EOA %s: %v",
 				roundStr, trialNumStr, eoa.Hex(), err)
 		}
 	} else {
@@ -1337,7 +1368,10 @@ func (n *LeaderNode) updateCommitDataAfterSubmit(ctx context.Context, uniqueKey 
 		} else {
 			data.SubmitMerkleRootDone = true
 			utils.SetCommittedNodeData(uniqueKey, eoaAddress, data)
-			n.leaderCommitRepository.UpdateLeaderCommit(ctx, &data)
+			err := n.leaderCommitRepository.UpdateLeaderCommit(ctx, &data)
+			if err != nil {
+				log.Printf("Error updating leader commits for the eoa address %v", eoaAddress)
+			}
 		}
 	}
 
@@ -1480,7 +1514,11 @@ type CvAndSigRS struct {
 
 // requestToSubmitCo submits on-chain request for missing COS values
 func (n *LeaderNode) requestToSubmitCo(ctx context.Context, roundNum string, trialNum string, missingIndices []*big.Int) {
-	cvNotOnChainCvAndSigRS, packedVs, indicesLength, packedOrederedIndices := n.prepareArgumentsForRequestToSubmitCo(ctx, roundNum, trialNum, missingIndices)
+	cvNotOnChainCvAndSigRS, packedVs, indicesLength, packedOrederedIndices, err := n.prepareArgumentsForRequestToSubmitCo(ctx, roundNum, trialNum, missingIndices)
+	if err != nil {
+		log.Printf("Failed to prepare arguments for requestToSubmitCo for round %s with trial %s: %v", roundNum, trialNum, err)
+		return
+	}
 
 	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
 	if err != nil {
@@ -1508,8 +1546,12 @@ func (n *LeaderNode) requestToSubmitCo(ctx context.Context, roundNum string, tri
 }
 
 // prepareArgumentsForRequestToSubmitCo prepares arguments for COS request
-func (n *LeaderNode) prepareArgumentsForRequestToSubmitCo(ctx context.Context, roundNum string, trialNum string, missingIndices []*big.Int) ([]CvAndSigRS, *big.Int, *big.Int, *big.Int) {
-	cvs, _, _, vs, rs, ss := n.LoadNodeData(ctx, roundNum, trialNum)
+func (n *LeaderNode) prepareArgumentsForRequestToSubmitCo(ctx context.Context, roundNum string, trialNum string, missingIndices []*big.Int) ([]CvAndSigRS, *big.Int, *big.Int, *big.Int, error) {
+	cvs, _, _, vs, rs, ss, err := n.LoadNodeData(ctx, roundNum, trialNum)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to load node data for round %s trial %s: %w", roundNum, trialNum, err)
+	}
+
 	indicesLength := big.NewInt(int64(len(missingIndices)))
 
 	notOnChainIndices, onChainIndices := n.orderedPackedIndices(missingIndices)
@@ -1537,7 +1579,7 @@ func (n *LeaderNode) prepareArgumentsForRequestToSubmitCo(ctx context.Context, r
 		cvNotOnChainCvAndSigRS = append(cvNotOnChainCvAndSigRS, cvAndSigRS)
 	}
 	packedVs := PackIndices(vsForNotOnChain)
-	return cvNotOnChainCvAndSigRS, packedVs, indicesLength, packedOrderedIndices
+	return cvNotOnChainCvAndSigRS, packedVs, indicesLength, packedOrderedIndices, nil
 }
 
 // orderedPackedIndices separates indices into on-chain and not-on-chain

--- a/nodes/leader/accept_commit_test.go
+++ b/nodes/leader/accept_commit_test.go
@@ -152,7 +152,7 @@ func (m *MockNodeInfoRepositoryForAcceptCommit) DeleteNodeInfoByEOA(ctx context.
 type MockEthServiceForAcceptCommit struct {
 	GetActivatedOperatorsCachedFunc func() []common.Address
 	GetActivatedOperatorsFunc       func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) ([]common.Address, error)
-	UpdateActivatedOperatorsFunc    func(ctx context.Context, client fallback_ethclient.IFallbackEthClient)
+	UpdateActivatedOperatorsFunc    func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error
 	CallSmartContractFunc           func(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error)
 	ExecuteTransactionFunc          func(ctx context.Context, clientUtils *utils.Client, fallbackEthClient fallback_ethclient.IFallbackEthClient, method string, value *big.Int, args ...interface{}) (*types.Transaction, *bind.TransactOpts, error)
 }
@@ -183,10 +183,11 @@ func (m *MockEthServiceForAcceptCommit) GetActivatedOperators(ctx context.Contex
 	return []common.Address{}, nil
 }
 
-func (m *MockEthServiceForAcceptCommit) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *MockEthServiceForAcceptCommit) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
 	if m.UpdateActivatedOperatorsFunc != nil {
-		m.UpdateActivatedOperatorsFunc(ctx, fallbackEthClient)
+		return m.UpdateActivatedOperatorsFunc(ctx, fallbackEthClient)
 	}
+	return nil
 }
 
 func (m *MockEthServiceForAcceptCommit) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {
@@ -332,7 +333,7 @@ func TestProcessCOS_Success(t *testing.T) {
 
 	// Mock
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), activatedOps[0].Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -712,7 +713,7 @@ func TestProcessCVS_UpdateExisting(t *testing.T) {
 	index := big.NewInt(0)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), activatedOps[0].Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -745,7 +746,7 @@ func TestProcessCOS_AddCommitError(t *testing.T) {
 
 	// Mock no existing commit and add error
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), activatedOps[0].Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("db error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -823,7 +824,7 @@ func TestProcessCVS_AddCommitError(t *testing.T) {
 
 	// Mock no existing commit with add error
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), activatedOps[0].Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(errors.New("db error"))
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -973,7 +974,8 @@ func TestPrepareArgumentsForRequestToSubmitCo(t *testing.T) {
 	missingIndices := []*big.Int{big.NewInt(0), big.NewInt(1)}
 
 	// Call prepare function
-	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices, err := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, cvAndSigRS)
 	assert.NotNil(t, packedVs)
@@ -1135,7 +1137,8 @@ func TestPrepareArgumentsForRequestToSubmitCo_SingleIndex(t *testing.T) {
 
 	missingIndices := []*big.Int{big.NewInt(0)}
 
-	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices, err := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, cvAndSigRS)
 	assert.NotNil(t, packedVs)
@@ -1204,7 +1207,8 @@ func TestPrepareArgumentsForRequestToSubmitCo_MultipleIndices(t *testing.T) {
 
 	missingIndices := []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)}
 
-	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	cvAndSigRS, packedVs, indicesLength, packedOrderedIndices, err := node.prepareArgumentsForRequestToSubmitCo(context.Background(), round, trialNum, missingIndices)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, cvAndSigRS)
 	assert.NotNil(t, packedVs)
@@ -1485,7 +1489,7 @@ func TestProcessCOS_WithMockEthService(t *testing.T) {
 	index := big.NewInt(0)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -1520,7 +1524,7 @@ func TestProcessCVS_WithMockEthService(t *testing.T) {
 	index := big.NewInt(0)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -2039,8 +2043,9 @@ func TestProcessRandomRequestNumber_StateOne(t *testing.T) {
 		GetActivatedOperatorsCachedFunc: func() []common.Address {
 			return []common.Address{testOp}
 		},
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
-			// No-op for test
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
+			// No-op
+			return nil
 		},
 	}
 	node.ethService = mockEth
@@ -2171,7 +2176,7 @@ func TestProcessCOS_StoresDataCorrectly(t *testing.T) {
 	index := big.NewInt(0)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -2212,7 +2217,7 @@ func TestProcessCVS_AllCvsReceivedTrigger(t *testing.T) {
 	index := big.NewInt(0)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -2515,8 +2520,9 @@ func TestProcessRandomRequestNumber_StateOneWithDeleteError(t *testing.T) {
 		GetActivatedOperatorsCachedFunc: func() []common.Address {
 			return []common.Address{testOp}
 		},
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 	node.ethService = mockEth
@@ -3059,7 +3065,7 @@ func TestProcessCOS_CheckStopMonitoring(t *testing.T) {
 	node.startFailToSubmitCoMonitoring(context.Background(), round.String(), trialNum.String(), timestamp)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -3105,7 +3111,7 @@ func TestProcessCVS_CheckStopMonitoring(t *testing.T) {
 	node.startFailToSubmitCvMonitoring(context.Background(), round.String(), trialNum.String(), timestamp)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, round.String(), trialNum.String(), testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -3268,7 +3274,7 @@ func TestLeaderNode_receiveCommit_SubscriptionFailure(t *testing.T) {
 
 	// Verify subscription was attempted at least once (allowing for retry logic)
 	assert.True(t, mockClient.AssertExpectations(t), "Mock expectations should be met")
-	
+
 	// Get call count in a race-safe way by checking if any calls were made
 	called := false
 	for _, call := range mockClient.ExpectedCalls {
@@ -3333,8 +3339,9 @@ func TestLeaderNode_receiveCommit_StatusEvent_State1(t *testing.T) {
 		Return(nil)
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 	node.ethService = mockEth
@@ -3414,7 +3421,7 @@ func TestLeaderNode_receiveCommit_CvSubmitted_Success(t *testing.T) {
 		}).Return(mockSub, nil)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, "100", "1", testOp.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -3487,7 +3494,7 @@ func TestLeaderNode_receiveCommit_CoSubmitted_Success(t *testing.T) {
 		}).Return(mockSub, nil)
 
 	mockLeaderRepo.On("GetLeaderCommitByRoundAndEoaAddr", mock.Anything, "100", "1", testOp1.Hex()).
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 	mockLeaderRepo.On("AddLeaderCommit", mock.Anything, mock.Anything).Return(nil)
 	mockBroadcastRepo.On("AddBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockBroadcastRepo.On("UpdateBroadcastTracker", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -4243,8 +4250,9 @@ func TestLeaderNode_processDeactivated_Success(t *testing.T) {
 	testOp := common.HexToAddress("0x1111111111111111111111111111111111111111")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -4271,8 +4279,9 @@ func TestLeaderNode_processDeactivated_DeleteError(t *testing.T) {
 	testOp := common.HexToAddress("0x2222222222222222222222222222222222222222")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -4388,7 +4397,8 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_Success(t *testing.T) {
 	require.Greater(t, len(conns), 0, "Connection should exist before deactivation")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
+    return nil
 		},
 	}
 
@@ -4434,7 +4444,8 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_NoConnection(t *testing
 	node.p2pClient.SetHost(testHost)
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
+    return nil
 		},
 	}
 
@@ -4471,7 +4482,8 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_InvalidPeerID(t *testin
 	testOp := common.HexToAddress("0x5555555555555555555555555555555555555555")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
+    return nil
 		},
 	}
 
@@ -4506,8 +4518,9 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_NilP2PClient(t *testing
 	testOp := common.HexToAddress("0x6666666666666666666666666666666666666666")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -4533,8 +4546,9 @@ func TestLeaderNode_processDeactivated_ConnectionCleanup_NilHostInstance(t *test
 	testOp := common.HexToAddress("0x7777777777777777777777777777777777777777")
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -5289,8 +5303,9 @@ func TestLeaderNode_receiveCommit_DeActivated_Success(t *testing.T) {
 	}
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -5406,8 +5421,9 @@ func TestLeaderNode_receiveCommit_DeActivated_DeleteNodeError(t *testing.T) {
 	}
 
 	mockEth := &MockEthServiceForAcceptCommit{
-		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+		UpdateActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
 			// No-op
+			return nil
 		},
 	}
 
@@ -6484,7 +6500,7 @@ func (m *ConcurrentMockLeaderCommitRepository) GetLeaderCommitByRoundAndEoaAddr(
 	if commit, exists := m.commits[key]; exists {
 		return commit, nil
 	}
-	return nil, errors.New("not found")
+	return nil, pg.ErrNoRows
 }
 
 func (m *ConcurrentMockLeaderCommitRepository) UpdateLeaderCommit(ctx context.Context, commitData *utils.LeaderCommitData) error {

--- a/nodes/leader/handler.go
+++ b/nodes/leader/handler.go
@@ -123,7 +123,9 @@ func (lh *LeaderNodeHandler) Run(ctx context.Context) {
 	log.Printf("Leader node running on: %s", h.Addrs())
 	log.Printf("Leader node PeerID: %s", peerID.String())
 
-	lh.ethService.UpdateActivatedOperators(ctx, lh.fallbackEthClient)
+	if err = lh.ethService.UpdateActivatedOperators(ctx, lh.fallbackEthClient); err != nil {
+		log.Printf("Failed to update activated operators: %v", err)
+	}
 
 	err = lh.leaderNode.UpdateCurrentRoundAndTrial(ctx)
 	if err != nil {
@@ -206,8 +208,6 @@ func (lh *LeaderNodeHandler) handleCommitRequest(ctx context.Context, s network.
 		commitData.SubmitMerkleRootDone = false
 		commitData.RandomNumberGenerated = false
 	}
-	lh.updateInMemoryData(uniqueKey, eoaAddress, *commitData)
-	log.Printf("Commit data saved and updated in-memory for round %s with trail %s EOA %s", round, trial, commitData.EOAAddress)
 
 	// Update database for commit data from regular node
 	if err := lh.leaderNode.AddLeaderCommit(ctx, commitData); err != nil {
@@ -215,6 +215,8 @@ func (lh *LeaderNodeHandler) handleCommitRequest(ctx context.Context, s network.
 		return
 	}
 	lh.updateInMemoryData(uniqueKey, eoaAddress, *commitData)
+	log.Printf("Commit data saved and updated in-memory for round %s with trail %s EOA %s", round, trial, commitData.EOAAddress)
+
 	activatedOps := lh.ethService.GetActivatedOperatorsCached()
 	lh.leaderNode.ReliableBroadCastCVS(ctx, round, trial, eoaAddress, commitData.Cvs, activatedOps)
 	// Check if all commits are ready after this update
@@ -303,7 +305,11 @@ func (lh *LeaderNodeHandler) handleCOSRequest(ctx context.Context, h host.Host, 
 	// Update database for leaderCommit's COS
 	leaderCommitDBData, err := lh.leaderNode.GetLeaderCommitByRoundAndEoaAddr(ctx, round, trial, eoaAddress.Hex())
 	if err != nil {
-		log.Printf("Error loading leaderCommit data from database for round: %s, trail: %s, and eoaAddress: %s, error: %v", round, trial, eoaAddress.Hex(), err)
+		if err == pg.ErrNoRows {
+			log.Printf("Leader commit data not found for round %s, trail %s, EOA %s. Cannot update COS.", round, trial, eoaAddress.Hex())
+			return
+		}
+		log.Printf("Database connection error while loading leader commit data for round %s, trail %s, EOA %s: %v", round, trial, eoaAddress.Hex(), err)
 		return
 	}
 
@@ -384,31 +390,6 @@ func (lh *LeaderNodeHandler) allCosReceivedUnlocked(uniqueKey string) bool {
 	return true
 }
 
-func (lh *LeaderNodeHandler) UpdatedallCommitsReceivedUnlocked(ctx context.Context, fallbackEthClient *fallback_ethclient.FallbackRPCClient, uniqueKey string) map[string]bool {
-	result := make(map[string]bool)
-	ops, _ := lh.ethService.GetActivatedOperators(ctx, fallbackEthClient)
-
-	roundCommits, roundExists := utils.GetCommittedNodes(uniqueKey)
-	if !roundExists || len(roundCommits) == 0 {
-		for _, op := range ops {
-			result[op.Hex()] = false
-		}
-	}
-
-	for _, op := range ops {
-		data, ok := roundCommits[op]
-		if ok {
-			if data.Cvs != [32]byte{} {
-				result[op.Hex()] = true
-			} else {
-				result[op.Hex()] = false
-			}
-		} else {
-			result[op.Hex()] = false
-		}
-	}
-	return result
-}
 
 // updateInMemoryData updates committedNodes with the latest commitData.
 // Called with commitMu locked.

--- a/nodes/leader/handler_test.go
+++ b/nodes/leader/handler_test.go
@@ -2364,8 +2364,9 @@ func (m *MockEthService) GetActivatedOperators(ctx context.Context, fallbackEthC
 	return []common.Address{}, nil
 }
 
-func (m *MockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *MockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
 	// No-op for tests
+	return nil
 }
 
 func (m *MockEthService) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {
@@ -2441,84 +2442,6 @@ func (suite *LeaderHandlerTestSuite) TestLeaderHandler_IsEOAActivatedForRound_Ne
 	assert.False(suite.T(), isActivated)
 }
 
-// TestLeaderHandler_UpdatedallCommitsReceivedUnlocked tests the updated commit check
-func (suite *LeaderHandlerTestSuite) TestLeaderHandler_UpdatedallCommitsReceivedUnlocked() {
-	testRound := "updated_commits_66"
-	testTrial := "1"
-	uniqueKey := utils.GetUniqueKey(testRound, testTrial)
-
-	testOp1 := common.HexToAddress("0x3333333333333333333333333333333333333333")
-	testOp2 := common.HexToAddress("0x4444444444444444444444444444444444444444")
-
-	mockEth := &MockEthService{
-		GetActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) ([]common.Address, error) {
-			return []common.Address{testOp1, testOp2}, nil
-		},
-	}
-
-	suite.leaderNodeHandler.ethService = mockEth
-
-	// Test with no data
-	result := suite.leaderNodeHandler.UpdatedallCommitsReceivedUnlocked(context.Background(), nil, uniqueKey)
-	assert.Len(suite.T(), result, 2)
-	assert.False(suite.T(), result[testOp1.Hex()])
-	assert.False(suite.T(), result[testOp2.Hex()])
-
-	// Add CVS for op1
-	utils.SetCommittedNodeData(uniqueKey, testOp1, utils.LeaderCommitData{Cvs: [32]byte{1}})
-
-	result = suite.leaderNodeHandler.UpdatedallCommitsReceivedUnlocked(context.Background(), nil, uniqueKey)
-	assert.True(suite.T(), result[testOp1.Hex()])
-	assert.False(suite.T(), result[testOp2.Hex()])
-
-	// Add CVS for op2
-	utils.SetCommittedNodeData(uniqueKey, testOp2, utils.LeaderCommitData{Cvs: [32]byte{2}})
-
-	result = suite.leaderNodeHandler.UpdatedallCommitsReceivedUnlocked(context.Background(), nil, uniqueKey)
-	assert.True(suite.T(), result[testOp1.Hex()])
-	assert.True(suite.T(), result[testOp2.Hex()])
-}
-
-// TestLeaderHandler_UpdatedallCommitsReceivedUnlocked_EmptyCVS tests the else block when CVS is empty
-func (suite *LeaderHandlerTestSuite) TestLeaderHandler_UpdatedallCommitsReceivedUnlocked_EmptyCVS() {
-	testRound := "updated_commits_empty_cvs_66b"
-	testTrial := "1"
-	uniqueKey := utils.GetUniqueKey(testRound, testTrial)
-
-	testOp1 := common.HexToAddress("0x5555555555555555555555555555555555555555")
-	testOp2 := common.HexToAddress("0x6666666666666666666666666666666666666666")
-
-	mockEth := &MockEthService{
-		GetActivatedOperatorsFunc: func(ctx context.Context, client fallback_ethclient.IFallbackEthClient) ([]common.Address, error) {
-			return []common.Address{testOp1, testOp2}, nil
-		},
-	}
-
-	suite.leaderNodeHandler.ethService = mockEth
-
-	// Create entry for op1 with EMPTY CVS (this triggers the else block at line 386)
-	utils.SetCommittedNodeData(uniqueKey, testOp1, utils.LeaderCommitData{
-		Round:      testRound,
-		TrialNum:   testTrial,
-		EOAAddress: testOp1.Hex(),
-		Cvs:        [32]byte{}, // Empty CVS - this should result in false
-	})
-
-	// Add valid CVS for op2
-	utils.SetCommittedNodeData(uniqueKey, testOp2, utils.LeaderCommitData{
-		Round:      testRound,
-		TrialNum:   testTrial,
-		EOAAddress: testOp2.Hex(),
-		Cvs:        [32]byte{1, 2, 3}, // Non-empty CVS - this should be true
-	})
-
-	result := suite.leaderNodeHandler.UpdatedallCommitsReceivedUnlocked(context.Background(), nil, uniqueKey)
-
-	// op1 exists in map but has empty CVS - should trigger else block and be false
-	assert.False(suite.T(), result[testOp1.Hex()], "Op1 with empty CVS should be false (else block)")
-	// op2 has valid CVS - should be true
-	assert.True(suite.T(), result[testOp2.Hex()], "Op2 with valid CVS should be true")
-}
 
 // TestLeaderHandler_CheckActivation_Success tests successful activation check
 func (suite *LeaderHandlerTestSuite) TestLeaderHandler_CheckActivation_Success() {

--- a/nodes/leader/monitor_commits.go
+++ b/nodes/leader/monitor_commits.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-pg/pg/v10"
 	appconfig "github.com/tokamak-network/DRB-node/config"
 	"github.com/tokamak-network/DRB-node/eth"
 	"github.com/tokamak-network/DRB-node/pkg/fallback_ethclient"
@@ -52,17 +53,24 @@ func (n *LeaderNode) checkRoundsForCompletion(ctx context.Context) {
 
 	// Defensive check: skip if all random_number_generated are already true for this round
 	leaderCommits, err := n.leaderCommitRepository.GetLeaderCommitsByRoundAndTrialNum(ctx, round, trialNum)
-	if err == nil && len(leaderCommits) > 0 {
-		allRandomNumberGenerated := true
-		for _, lc := range leaderCommits {
-			if !lc.RandomNumberGenerated {
-				allRandomNumberGenerated = false
-				break
-			}
+	if err != nil {
+		log.Printf("Database connection error while getting leader commits for round %s with trial %s: %v", round, trialNum, err)
+		return
+	}
+	if len(leaderCommits) == 0 {
+		log.Printf("No leader commits found for round %s with trial %s. Skipping check.", round, trialNum)
+		return
+	}
+
+	allRandomNumberGenerated := true
+	for _, lc := range leaderCommits {
+		if !lc.RandomNumberGenerated {
+			allRandomNumberGenerated = false
+			break
 		}
-		if allRandomNumberGenerated {
-			return
-		}
+	}
+	if allRandomNumberGenerated {
+		return
 	}
 
 	// Copy the activated operators from eth package
@@ -80,7 +88,11 @@ func (n *LeaderNode) checkRoundsForCompletion(ctx context.Context) {
 	for i, operator := range operatorAddresses {
 		commitData, err := n.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, round, trialNum, operator.Hex())
 		if err != nil {
-			log.Printf("Either Data not found or Error getting commit data for operator %s: %v", operator.Hex(), err)
+			if err == pg.ErrNoRows {
+				log.Printf("Leader commit data not found for operator %s in round %s with trial %s. Cannot process.", operator.Hex(), round, trialNum)
+			} else {
+				log.Printf("Database connection error while getting commit data for operator %s in round %s with trial %s: %v", operator.Hex(), round, trialNum, err)
+			}
 			return
 		} else {
 			if commitData.SecretValue == [32]byte{} {
@@ -162,11 +174,16 @@ func (n *LeaderNode) FetchActivatedOperators(ctx context.Context, fallbackEthCli
 	return strAddresses, nil
 }
 
-func (n *LeaderNode) LoadNodeData(ctx context.Context, round string, trialNum string) ([][]byte, [][]byte, [][]byte, []uint8, []common.Hash, []common.Hash) {
+func (n *LeaderNode) LoadNodeData(ctx context.Context, round string, trialNum string) ([][]byte, [][]byte, [][]byte, []uint8, []common.Hash, []common.Hash, error) {
 
 	leaderCommits, err := n.leaderCommitRepository.GetLeaderCommitsByRoundAndTrialNum(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load leader commits: %v", err)
+		log.Printf("Database connection error while loading leader commits for round %s with trial %s: %v", round, trialNum, err)
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	if len(leaderCommits) == 0 {
+		log.Printf("No leader commits found for round %s with trial %s. Returning empty data.", round, trialNum)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("no leader commits found for round %s with trial %s", round, trialNum)
 	}
 
 	// Sort leaderCommits based on ActivatedOperators order
@@ -215,7 +232,7 @@ func (n *LeaderNode) LoadNodeData(ctx context.Context, round string, trialNum st
 		}
 	}
 
-	return cvs, cos, secrets, vs, rs, ss
+	return cvs, cos, secrets, vs, rs, ss, nil
 }
 
 // Updated function to use utils.LeaderCommitData
@@ -289,7 +306,11 @@ func (n *LeaderNode) generateRandomNumberTransaction(ctx context.Context, round 
 
 	roundRevealData, err := n.reavealOrderRepository.GetRevealOrder(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load reveal order: %v", err)
+		if err == pg.ErrNoRows {
+			log.Printf("Reveal order not found for round %s with trial %s.", round, trialNum)
+		} else {
+			log.Printf("Database connection error while loading reveal order for round %s with trial %s: %v", round, trialNum, err)
+		}
 		return err
 	}
 
@@ -342,7 +363,11 @@ func (n *LeaderNode) generateRandomNumberTransactionSomeCvOnChain(ctx context.Co
 
 	roundRevealData, err := n.reavealOrderRepository.GetRevealOrder(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load reveal order: %v", err)
+		if err == pg.ErrNoRows {
+			log.Printf("Reveal order not found for round %s with trial %s. Cannot generate random number.", round, trialNum)
+		} else {
+			log.Printf("Database connection error while loading reveal order for round %s with trial %s: %v", round, trialNum, err)
+		}
 		return err
 	}
 

--- a/nodes/leader/monitor_commits_test.go
+++ b/nodes/leader/monitor_commits_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/go-pg/pg/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -220,7 +221,7 @@ type mockLeaderCommitRepo struct {
 	updateRandomHit int
 }
 
-var errNotFound = errors.New("not found")
+var errNotFound = pg.ErrNoRows
 
 func (m *mockLeaderCommitRepo) GetLeaderCommitByRoundAndEoaAddr(ctx context.Context, round, trialNum, eoaAddress string) (*utils.LeaderCommitData, error) {
 	if m.getErr != nil {
@@ -265,7 +266,8 @@ func (m *mockEthServiceWithError) GetActivatedOperatorsUnsafe() []common.Address
 func (m *mockEthServiceWithError) GetActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) ([]common.Address, error) {
 	return nil, errors.New("network error")
 }
-func (m *mockEthServiceWithError) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *mockEthServiceWithError) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
+	return nil
 }
 func (m *mockEthServiceWithError) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {
 	return nil, nil
@@ -355,7 +357,8 @@ func (m *mockEthService) GetActivatedOperatorsUnsafe() []common.Address { return
 func (m *mockEthService) GetActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) ([]common.Address, error) {
 	return append([]common.Address{}, m.operators...), nil
 }
-func (m *mockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *mockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
+	return nil
 }
 func (m *mockEthService) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {
 	return nil, nil
@@ -484,7 +487,8 @@ func (s *MonitorCommitsSuite) Test_LoadNodeData_ParsesAndDefaults() {
 	lc2 := makeLeaderCommit(addr2, true, "", common.Hash{}, common.Hash{})
 	s.lcRepo.byRoundTrial = []*utils.LeaderCommitData{lc2, lc1}
 
-	cvs, cos, secrets, vs, rs, ss := s.ln.LoadNodeData(s.ctx, "1", "1")
+	cvs, cos, secrets, vs, rs, ss, err := s.ln.LoadNodeData(s.ctx, "1", "1")
+	s.Require().NoError(err)
 	s.Require().Len(secrets, 2)
 	s.Equal(byte(0), vs[1]) // second commit had empty v
 	s.Equal(common.Hash{}, rs[1])
@@ -615,7 +619,7 @@ func TestLeaderNode_checkRoundsForCompletion_MissingCommitData(t *testing.T) {
 	defer func() { eth.Service = originalService }()
 
 	mockRepo := &mockLeaderCommitRepo{
-		getErr: errors.New("commit data not found"),
+		getErr: pg.ErrNoRows,
 	}
 
 	ln := &LeaderNode{
@@ -1230,7 +1234,7 @@ func TestLeaderNode_generateRandomNumberTransaction_RevealOrderError(t *testing.
 	}()
 
 	mockRevealRepo := &mockRevealOrderRepo{
-		err: errors.New("reveal order not found"),
+		err: pg.ErrNoRows,
 	}
 
 	ln := &LeaderNode{
@@ -1245,7 +1249,7 @@ func TestLeaderNode_generateRandomNumberTransaction_RevealOrderError(t *testing.
 	err := ln.generateRandomNumberTransaction(context.Background(), "1", "1", secrets, vs, rs, ss)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "reveal order not found")
+	assert.True(t, errors.Is(err, pg.ErrNoRows), "Expected pg.ErrNoRows error")
 }
 
 func TestLeaderNode_generateRandomNumberTransaction_ExecuteTransactionError(t *testing.T) {
@@ -1364,7 +1368,7 @@ func TestLeaderNode_generateRandomNumberTransactionSomeCvOnChain_RevealOrderErro
 	}()
 
 	mockRevealRepo := &mockRevealOrderRepo{
-		err: errors.New("reveal order not found"),
+		err: pg.ErrNoRows,
 	}
 
 	ln := &LeaderNode{
@@ -1379,7 +1383,7 @@ func TestLeaderNode_generateRandomNumberTransactionSomeCvOnChain_RevealOrderErro
 	err := ln.generateRandomNumberTransactionSomeCvOnChain(context.Background(), "1", "1", secrets, vs, rs, ss)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "reveal order not found")
+	assert.True(t, errors.Is(err, pg.ErrNoRows), "Expected pg.ErrNoRows error")
 }
 
 func TestLeaderNode_completeRound_Success(t *testing.T) {
@@ -1462,8 +1466,9 @@ func TestLeaderNode_LoadNodeData_LoadError(t *testing.T) {
 	}
 
 	// Should handle error gracefully and return empty slices
-	cvs, cos, secrets, vs, rs, ss := ln.LoadNodeData(context.Background(), "1", "1")
+	cvs, cos, secrets, vs, rs, ss, err := ln.LoadNodeData(context.Background(), "1", "1")
 
+	assert.Error(t, err)
 	assert.Empty(t, cvs)
 	assert.Empty(t, cos)
 	assert.Empty(t, secrets)
@@ -1504,7 +1509,8 @@ func TestLeaderNode_LoadNodeData_ParseError(t *testing.T) {
 		leaderCommitRepository: mockRepo,
 	}
 
-	cvs, cos, secrets, vs, rs, ss := ln.LoadNodeData(context.Background(), "1", "1")
+	cvs, cos, secrets, vs, rs, ss, err := ln.LoadNodeData(context.Background(), "1", "1")
+	assert.NoError(t, err)
 
 	// Should still process but with v = 0 for invalid parse
 	assert.Len(t, cvs, 1)

--- a/nodes/leader/registration_helper.go
+++ b/nodes/leader/registration_helper.go
@@ -41,7 +41,9 @@ func (n *LeaderNode) registerNodeInternal(ctx context.Context, req utils.Registr
 
 	log.Printf("Verified registration for PeerID: %s", req.PeerID)
 	if n.fallbackEthClient != nil {
-		eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient)
+		if err := eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient); err != nil {
+			log.Printf("Failed to update activated operators during registration: %v", err)
+		}
 	}
 	operators := eth.Service.GetActivatedOperatorsCached()
 

--- a/nodes/leader/reveal_requests.go
+++ b/nodes/leader/reveal_requests.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/go-pg/pg/v10"
 	"github.com/libp2p/go-libp2p/core/host"
 	appconfig "github.com/tokamak-network/DRB-node/config"
 	"github.com/tokamak-network/DRB-node/eth"
@@ -26,14 +27,22 @@ func (n *LeaderNode) StartSecretValueRequests(ctx context.Context, h host.Host, 
 	uniqueKey := utils.GetUniqueKey(round, trialNum)
 	roundRevealData, err := n.reavealOrderRepository.GetRevealOrder(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load reveal order: %v", err)
+		if err == pg.ErrNoRows {
+			log.Printf("Reveal order not found for round %s with trial %s. Cannot start secret value requests.", round, trialNum)
+		} else {
+			log.Printf("Database connection error while loading reveal order for round %s with trial %s: %v", round, trialNum, err)
+		}
 		return
 	}
 
 	// Load registered nodes
 	nodes, err := n.nodeInfoRepository.GetNodeInfos(ctx)
 	if err != nil {
-		log.Printf("Failed to load registered nodes: %v", err)
+		if len(nodes) == 0 {
+			log.Printf("No node infos found. Cannot start secret value requests.")
+		} else {
+			log.Printf("Database connection error while loading registered nodes: %v", err)
+		}
 		return
 	}
 
@@ -122,7 +131,12 @@ func (n *LeaderNode) sendSecretValueRequestToNode(ctx context.Context, h host.Ho
 
 func (n *LeaderNode) requestToSubmitS(ctx context.Context, round string, trialNum string) {
 	n.SetSecretRequestSentForWhichRound(n.GetCurrentRound())
-	allCos, secretsReceivedOffchainInRevealOrder, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders := n.prepareArgumentsForRequestToSubmitS(ctx, round, trialNum)
+	allCos, secretsReceivedOffchainInRevealOrder, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders, err := n.prepareArgumentsForRequestToSubmitS(ctx, round, trialNum)
+	if err != nil {
+		log.Printf("Failed to prepare arguments for requestToSubmitS: %v", err)
+		return
+	}
+
 	clientUtils, err := utils.NewLeaderClient("contract/abi/Commit2RevealDRB.json")
 	if err != nil {
 		log.Printf("Failed to create leader client: %v", err)
@@ -153,8 +167,11 @@ func (n *LeaderNode) requestToSubmitS(ctx context.Context, round string, trialNu
 	n.StartFailToSubmitSMonitoring(ctx, round, trialNum, requestTimestamp)
 }
 
-func (n *LeaderNode) prepareArgumentsForRequestToSubmitS(ctx context.Context, round string, trialNum string) ([][32]byte, [][32]byte, *big.Int, []SigRS, *big.Int) {
-	_, cos, _, vs, rs, ss := n.LoadNodeData(ctx, round, trialNum)
+func (n *LeaderNode) prepareArgumentsForRequestToSubmitS(ctx context.Context, round string, trialNum string) ([][32]byte, [][32]byte, *big.Int, []SigRS, *big.Int, error) {
+	_, cos, _, vs, rs, ss, err := n.LoadNodeData(ctx, round, trialNum)
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to load node data for round %s trial %s: %w", round, trialNum, err)
+	}
 	var notOnChainIndices []*big.Int
 	i := big.NewInt(0)
 	j := 0
@@ -194,7 +211,12 @@ func (n *LeaderNode) prepareArgumentsForRequestToSubmitS(ctx context.Context, ro
 	uniqueKey := utils.GetUniqueKey(round, trialNum)
 	revealOrders, err := n.reavealOrderRepository.GetRevealOrder(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load reveal order for round %s with trail %s: %v", round, trialNum, err)
+		if err == pg.ErrNoRows {
+			log.Printf("Reveal order not found for round %s with trail %s. Cannot prepare arguments for requestToSubmitS.", round, trialNum)
+		} else {
+			log.Printf("Database connection error while loading reveal order for round %s with trail %s: %v", round, trialNum, err)
+		}
+		return nil, nil, nil, nil, nil, err
 	}
 
 	order := revealOrders.RevealOrder
@@ -202,7 +224,7 @@ func (n *LeaderNode) prepareArgumentsForRequestToSubmitS(ctx context.Context, ro
 	packedVsForAllCvsNotOnChain := packVsValues(vsForNotOnChain)
 
 	roundSecrets, _ := n.GetRoundSecretsValue(uniqueKey)
-	return allCos, roundSecrets, packedVsForAllCvsNotOnChain, sigRSsForAllCvsNotOnChain, packedRevealOrders
+	return allCos, roundSecrets, packedVsForAllCvsNotOnChain, sigRSsForAllCvsNotOnChain, packedRevealOrders, nil
 }
 
 func PackIndices(indices []*big.Int) *big.Int {
@@ -224,14 +246,22 @@ func (n *LeaderNode) HandleSecretValueResponse(ctx context.Context, h host.Host,
 	// Load reveal order for the round
 	roundRevealData, err := n.reavealOrderRepository.GetRevealOrder(ctx, round, trialNum)
 	if err != nil {
-		log.Printf("Failed to load reveal order: %v", err)
+		if err == pg.ErrNoRows {
+			log.Printf("Reveal order not found for round %s with trial %s. Cannot handle secret value response.", round, trialNum)
+		} else {
+			log.Printf("Database connection error while loading reveal order for round %s with trial %s: %v", round, trialNum, err)
+		}
 		return
 	}
 
 	// Load registered nodes
 	nodes, err := n.nodeInfoRepository.GetNodeInfos(ctx)
 	if err != nil {
-		log.Printf("Failed to load registered nodes: %v", err)
+		if len(nodes) == 0 {
+			log.Printf("No node infos found. Cannot handle secret value response.")
+		} else {
+			log.Printf("Database connection error while loading registered nodes: %v", err)
+		}
 		return
 	}
 

--- a/nodes/leader/reveal_requests_test.go
+++ b/nodes/leader/reveal_requests_test.go
@@ -658,7 +658,8 @@ func (suite *RevealRequestsTestSuite) TestPrepareArgumentsForRequestToSubmitS() 
 	suite.leaderNode.AppendToRoundSecrets(uniqueKey, secret)
 
 	// Call prepare function
-	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders, err := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	assert.NoError(suite.T(), err)
 
 	assert.NotNil(suite.T(), allCos)
 	assert.NotNil(suite.T(), secretsReceived)
@@ -992,7 +993,8 @@ func (suite *RevealRequestsTestSuite) TestLoadNodeDataIntegration() {
 		Where("round = ? AND trial_num = ?", testRound, testTrial).
 		Delete()
 
-	commits, cosArray, cvsArray, vs, rs, ss := suite.leaderNode.LoadNodeData(context.Background(), testRound, testTrial)
+	commits, cosArray, cvsArray, vs, rs, ss, err := suite.leaderNode.LoadNodeData(context.Background(), testRound, testTrial)
+	assert.NoError(suite.T(), err)
 
 	assert.NotNil(suite.T(), commits)
 	assert.Len(suite.T(), commits, 1)
@@ -1093,7 +1095,8 @@ func (suite *RevealRequestsTestSuite) TestPrepareArguments_Comprehensive() {
 	suite.leaderNode.AppendToRoundSecrets(uniqueKey, secret)
 
 	// Call prepare function
-	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders, err := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	assert.NoError(suite.T(), err)
 
 	assert.NotNil(suite.T(), allCos)
 	assert.Len(suite.T(), allCos, 1)
@@ -1365,7 +1368,8 @@ func (suite *RevealRequestsTestSuite) TestPrepareArguments_NoIndices() {
 	suite.leaderNode.indicesMutex.Unlock()
 
 	// Call prepare function - all operators are not on chain
-	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders, err := suite.leaderNode.prepareArgumentsForRequestToSubmitS(context.Background(), testRound, testTrial)
+	assert.NoError(suite.T(), err)
 
 	assert.NotNil(suite.T(), allCos)
 	assert.Len(suite.T(), allCos, 1)
@@ -2653,7 +2657,8 @@ func (suite *RevealRequestsTestSuite) TestPrepareArgumentsForRequestToSubmitS_Wi
 	suite.leaderNode.AppendToRoundSecrets(uniqueKey, secret2)
 
 	// Call prepare function - should handle indices correctly
-	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders := suite.leaderNode.prepareArgumentsForRequestToSubmitS(ctx, testRound, testTrial)
+	allCos, secretsReceived, packedVs, cvNotOnChainCvAndSigRS, packedRevealOrders, err := suite.leaderNode.prepareArgumentsForRequestToSubmitS(ctx, testRound, testTrial)
+	assert.NoError(suite.T(), err)
 
 	assert.NotNil(suite.T(), allCos)
 	assert.Len(suite.T(), allCos, 2) // Both operators

--- a/nodes/leader/secret_value_handler.go
+++ b/nodes/leader/secret_value_handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/go-pg/pg/v10"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	commitreveal2 "github.com/tokamak-network/DRB-node/commit-reveal2"
@@ -110,7 +111,11 @@ func (n *LeaderNode) AcceptSecretValue(ctx context.Context, h host.Host, s netwo
 	// Fetch or initialize the leader commit data for the given round and EOA
 	leaderCommitData, err := n.leaderCommitRepository.GetLeaderCommitByRoundAndEoaAddr(ctx, round, trial, req.RegularEoaAddress)
 	if err != nil {
-		log.Printf("Commit data not found  for round %s with trail %s EOA %s.", round, trial, eoaAddress.Hex())
+		if err == pg.ErrNoRows {
+			log.Printf("Leader commit data not found for round %s with trail %s EOA %s. Cannot process secret value.", round, trial, eoaAddress.Hex())
+		} else {
+			log.Printf("Database connection error while getting leader commit data for round %s with trail %s EOA %s: %v", round, trial, eoaAddress.Hex(), err)
+		}
 		return
 	}
 

--- a/nodes/leader/secret_value_handler_test.go
+++ b/nodes/leader/secret_value_handler_test.go
@@ -221,7 +221,8 @@ func (m *MockEthServiceForSecretHandler) ExecuteTransaction(ctx context.Context,
 	return tx, auth, nil
 }
 
-func (m *MockEthServiceForSecretHandler) UpdateActivatedOperators(ctx context.Context, client fallback_ethclient.IFallbackEthClient) {
+func (m *MockEthServiceForSecretHandler) UpdateActivatedOperators(ctx context.Context, client fallback_ethclient.IFallbackEthClient) error {
+	return nil
 }
 
 // MockRevealOrderRepository mocks the reveal order repository

--- a/nodes/regular/handler.go
+++ b/nodes/regular/handler.go
@@ -299,9 +299,13 @@ func (rh *RegularNodeHandler) Run(ctx context.Context) {
 
 			// Check if this round has already been committed (store it locally)
 			commitData, err := rh.regularNode.GetCommitByRound(ctx, round, trialNum)
-			if err != nil && err.Error() != "pg: no rows in result set" {
-				log.Printf("Error loading commit data: %v", err)
-				continue
+			if err != nil {
+				if err == pg.ErrNoRows {
+					log.Printf("Commit data not found for round %s with trial %s. This is expected for new rounds.", round, trialNum)
+				} else {
+					log.Printf("Database connection error while loading commit data for round %s with trial %s: %v", round, trialNum, err)
+					continue
+				}
 			}
 
 			// If commitData exists, we should only skip the round if both MerkleRoot and RandomNumber are nil

--- a/nodes/regular/handler_test.go
+++ b/nodes/regular/handler_test.go
@@ -586,8 +586,9 @@ func (m *MockEthService) GetActivatedOperators(ctx context.Context, fallbackEthC
 	return []common.Address{}, nil
 }
 
-func (m *MockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) {
+func (m *MockEthService) UpdateActivatedOperators(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient) error {
 	// No-op for tests
+	return nil
 }
 
 func (m *MockEthService) CallSmartContract(ctx context.Context, fallbackEthClient fallback_ethclient.IFallbackEthClient, parsedABI abi.ABI, method string, contractAddress common.Address, params ...interface{}) (interface{}, error) {

--- a/nodes/regular/receive_values.go
+++ b/nodes/regular/receive_values.go
@@ -100,7 +100,7 @@ func (n *RegularNode) HandleCvs(ctx context.Context, h host.Host, s network.Stre
 				return
 			}
 		} else {
-			log.Printf("Failed to get peer commit data: %v", err)
+			log.Printf("Database connection error while getting peer commit data for round %s, trial %s, EOA %s: %v", message.Round, message.TrialNum, message.EOAAddress, err)
 			return
 		}
 	} else {
@@ -201,7 +201,7 @@ func (n *RegularNode) HandleCos(ctx context.Context, h host.Host, s network.Stre
 				return
 			}
 		} else {
-			log.Printf("Failed to get peer commit data: %v", err)
+			log.Printf("Database connection error while getting peer commit data for round %s, trial %s, EOA %s: %v", message.Round, message.TrialNum, message.EOAAddress, err)
 			return
 		}
 	} else {
@@ -298,7 +298,7 @@ func (n *RegularNode) HandleSecret(ctx context.Context, h host.Host, s network.S
 				return
 			}
 		} else {
-			log.Printf("Failed to get peer commit data: %v", err)
+			log.Printf("Database connection error while getting peer commit data for round %s, trial %s, EOA %s: %v", message.Round, message.TrialNum, message.EOAAddress, err)
 			return
 		}
 	} else {

--- a/nodes/regular/secret_handler.go
+++ b/nodes/regular/secret_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/go-pg/pg/v10"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -20,7 +21,11 @@ func (n *RegularNode) checkPreviousSecretReceived(ctx context.Context, round, tr
 	// Check if we have the peer commit data (from broadcast) for the previous node
 	peerCommitData, err := n.peerCommitDataRepository.GetPeerCommitData(ctx, round, trialNum, previousNodeEOA)
 	if err != nil {
-		log.Printf("Failed to get peer commit data for previous node %s: %v", previousNodeEOA, err)
+		if err == pg.ErrNoRows {
+			log.Printf("Previous node %s secret not yet received (no data found)", previousNodeEOA)
+			return false
+		}
+		log.Printf("Database connection error while checking previous node %s secret: %v", previousNodeEOA, err)
 		return false
 	}
 
@@ -74,7 +79,12 @@ func (n *RegularNode) HandleSecretValueRequest(ctx context.Context, h host.Host,
 	for {
 		roundData, err := n.revealOrderRepository.GetRevealOrder(ctx, req.Round, req.TrialNum)
 		if err != nil {
-			log.Printf("Failed to load reveal order with trail %s for round %s: %v", req.TrialNum, req.Round, err)
+			if err == pg.ErrNoRows {
+				log.Printf("Reveal order not yet calculated for round %s with trail %s. Waiting...", req.Round, req.TrialNum)
+			} else {
+				log.Printf("Database connection error while loading reveal order for round %s with trail %s: %v", req.Round, req.TrialNum, err)
+				return
+			}
 		} else if roundData != nil {
 			n.SetStrictOrder(uniqueKey, roundData.OrderedNodes)
 			break
@@ -124,7 +134,11 @@ func (n *RegularNode) HandleSecretValueRequest(ctx context.Context, h host.Host,
 	// Fetch the secret value for the specified round
 	commitData, err := n.regularCommitRepository.GetCommitByRound(ctx, req.Round, req.TrialNum)
 	if err != nil {
-		log.Printf("Failed to load commit data for round %s with trail %s: %v", req.Round, req.TrialNum, err)
+		if err == pg.ErrNoRows {
+			log.Printf("Commit data not found for round %s with trail %s. Cannot send secret value.", req.Round, req.TrialNum)
+			return
+		}
+		log.Printf("Database connection error while loading commit data for round %s with trail %s: %v", req.Round, req.TrialNum, err)
 		return
 	}
 
@@ -159,7 +173,11 @@ func (n *RegularNode) SendSecretValue(ctx context.Context, h host.Host, leaderPe
 	// Load the commit data for the specified round
 	commitData, err := n.regularCommitRepository.GetCommitByRound(ctx, roundNum, trialNum)
 	if err != nil {
-		log.Printf("Failed to load commit data for round %s with trial %s: %v", roundNum, trialNum, err)
+		if err == pg.ErrNoRows {
+			log.Printf("Commit data not found for round %s with trial %s. Cannot send secret value.", roundNum, trialNum)
+			return
+		}
+		log.Printf("Database connection error while loading commit data for round %s with trial %s: %v", roundNum, trialNum, err)
 		return
 	}
 

--- a/nodes/regular/secret_handler_test.go
+++ b/nodes/regular/secret_handler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tokamak-network/DRB-node/utils"
 )
 
-
 func createTestNodeForSecretHandler() *RegularNode {
 	mockPeerRepo := new(MockPeerCommitRepository)
 	mockRevealRepo := new(MockRevealOrderRepository)
@@ -222,7 +221,7 @@ func TestRegularNode_HandleSecretValueRequest_GetRevealOrderError(t *testing.T) 
 
 	// Mock reveal order to return error multiple times
 	mockRevealRepo.On("GetRevealOrder", mock.Anything, "100", "1").
-		Return(nil, errors.New("not found")).Maybe()
+		Return(nil, pg.ErrNoRows).Maybe()
 
 	// Set a short timeout context
 	ctx, cancel := context.WithTimeout(context.Background(), 100*1000000)
@@ -497,7 +496,7 @@ func TestRegularNode_HandleSecretValueRequest_CommitDataNotFound(t *testing.T) {
 	mockRevealRepo.On("GetRevealOrder", mock.Anything, "100", "1").
 		Return(revealOrder, nil)
 	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 
 	stream := newMockStream()
 	jsonData, _ := json.Marshal(req)
@@ -801,7 +800,7 @@ func TestRegularNode_SendSecretValue_CommitDataNotFound(t *testing.T) {
 	defer h.Close()
 
 	mockCommitRepo.On("GetCommitByRound", mock.Anything, "100", "1").
-		Return(nil, errors.New("not found"))
+		Return(nil, pg.ErrNoRows)
 
 	node.SendSecretValue(context.Background(), h, h.ID(), "100", "1")
 

--- a/nodes/regular/send_commit.go
+++ b/nodes/regular/send_commit.go
@@ -496,7 +496,9 @@ func (n *RegularNode) processRandomRequestNumber(ctx context.Context, blockTimes
 	// Store the current round and trialNum from Status event
 	n.SetCurrentTrialNum(trialNum.String())
 
-	eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient)
+	if err := eth.Service.UpdateActivatedOperators(ctx, n.fallbackEthClient); err != nil {
+		log.Printf("Failed to update activated operators: %v", err)
+	}
 	n.SetCurrentRound(round.String())
 
 	if state.Cmp(big.NewInt(1)) == 0 {

--- a/testing/5_concurrency_advanced/atomic_corruption_edge_cases_test.go
+++ b/testing/5_concurrency_advanced/atomic_corruption_edge_cases_test.go
@@ -371,5 +371,6 @@ func generateRandomString(length int) string {
 // Helper function to create test regular node (properly initialized)
 func createTestRegularNode() *regular_node.RegularNode {
 	// Properly initialize RegularNode with all atomic fields and maps initialized
-	return regular_node.NewRegularNode(nil, nil, nil, nil, nil, nil, nil, nil)
+	regularNode, _ := regular_node.NewRegularNode(nil, nil, nil, nil, nil, nil, nil, nil)
+	return regularNode
 }


### PR DESCRIPTION
Distinguish between pg.ErrNoRows (not found) and actual database connection/query errors across leader and regular
   node code, providing clearer log messages for each case                                                            
  - Add missing error checks for previously ignored return values (UpdateActivatedOperators, UpdateLeaderCommit,      
  DeleteRoundTrialDataForLeaderNode, etc.)                                                                            
  - Propagate errors from LoadNodeData, prepareArgumentsForRequestToSubmitS, and prepareArgumentsForRequestToSubmitCo 
  instead of silently continuing with nil/empty data                                                                  
  - Fix in-memory data update ordering in handleCommitRequest — only update in-memory state after successful database 
  write                                                                                                               
  - Remove unused UpdatedallCommitsReceivedUnlocked function                                                                                         