### PR TITLE
Update libp2p connection parameters based on protocol analysis

### DIFF
--- a/docs/network-limits.md
+++ b/docs/network-limits.md
@@ -1,0 +1,114 @@
+# LibP2P Resource Manager Limits
+
+This document explains how the libp2p resource manager parameters are calculated in `calculateOptimalLimits()` (`libp2putils/libp2p_client.go`).
+
+## Network Topology
+
+- **Leader node**: Connected to up to `maxOperators` (default 32) regular nodes
+- **Regular node**: Connected to 1 leader node
+
+## Stream Protocols
+
+| Direction (relative to leader) | Protocol | Description |
+|---|---|---|
+| Inbound | `/register` | Regular node registration |
+| Inbound | `/cvs` | CVS commitment submission |
+| Inbound | `/cos` | COS submission |
+| Inbound | `/secretValue` | Secret value revelation |
+| Inbound | `/acknowledgment` | Broadcast receipt acknowledgment |
+| Outbound | `/cvsBroadcast` | Broadcast CVS to all operators |
+| Outbound | `/cosBroadcast` | Broadcast COS to all operators |
+| Outbound | `/secretBroadcast` | Broadcast secret to all operators |
+
+## Leader Node Calculations
+
+Rounds execute sequentially. Values below are for a single round with `maxOperators = 32`.
+
+### Connections
+
+| Parameter | Value | Formula |
+|---|---|---|
+| `ConnsInbound` | 40 | `maxOperators + 25% buffer` |
+| `ConnsOutbound` | 40 | Same as inbound (symmetric) |
+
+### Streams (per round)
+
+**Inbound = 3200 streams:**
+
+| Source | Count | Calculation |
+|---|---|---|
+| Registration | 32 | 1 per operator |
+| CVS commits | 32 | 1 per operator |
+| CVS acks | 1024 | 32 CVS values × 32 operators acknowledging each |
+| COS submissions | 32 | 1 per operator |
+| COS acks | 1024 | 32 COS values × 32 operators acknowledging each |
+| Secret submissions | 32 | 1 per operator |
+| Secret acks | 1024 | 32 secret values × 32 operators acknowledging each |
+
+**Outbound = 3072 streams:**
+
+| Source | Count | Calculation |
+|---|---|---|
+| CVS broadcasts | 1024 | 32 CVS values × 32 operators |
+| COS broadcasts | 1024 | 32 COS values × 32 operators |
+| Secret broadcasts | 1024 | 32 secret values × 32 operators |
+
+A **25% safety margin** is applied to both, giving final values of **4000 inbound** and **3840 outbound**.
+
+### Per-Connection Limits
+
+| Parameter | Value | Reasoning |
+|---|---|---|
+| `ConnBaseLimit.StreamsInbound` | 96 | Per regular node: 32 CVS acks + 32 COS acks + 32 Secret acks |
+| `ConnBaseLimit.StreamsOutbound` | 10 | Per regular node: broadcasts + overhead |
+
+### File Descriptors and Memory
+
+| Parameter | Value | Formula |
+|---|---|---|
+| `FD` | 160 | `estimatedConnections × 4` (~4 FDs per connection) |
+| `Memory` | ~530MB | `connections × 512KB + streams × 32KB + 256MB base` |
+
+## Regular Node Calculations
+
+A regular node only connects to the leader. It receives broadcasts for all operators and sends acks.
+
+### Connections
+
+| Parameter | Value | Reasoning |
+|---|---|---|
+| `ConnsInbound` | 2 | Leader + potential reconnection |
+| `ConnsOutbound` | 2 | Leader + backup |
+
+### Streams (per round, worst case)
+
+The leader retries broadcasts up to **3 times** if no acknowledgment is received.
+
+**Inbound = `3 × maxOperators × 3 retries` = 288 streams:**
+
+| Source | Count | Calculation |
+|---|---|---|
+| CVS broadcasts | 96 | 32 operators × 3 retries |
+| COS broadcasts | 96 | 32 operators × 3 retries |
+| Secret broadcasts | 96 | 32 operators × 3 retries |
+
+**Outbound = `3 + (3 × maxOperators)` = 99 streams:**
+
+| Source | Count | Calculation |
+|---|---|---|
+| CVS commit | 1 | Own commitment |
+| COS submission | 1 | Own COS |
+| Secret submission | 1 | Own secret |
+| ACKs | 96 | 1 ack per successfully received broadcast (32 operators × 3 phases) |
+
+### Per-Connection Limits
+
+Per-connection limits equal system limits since the regular node has only one meaningful connection (to the leader).
+
+### File Descriptors and Memory
+
+| Parameter | Value | Formula |
+|---|---|---|
+| `FD` | 32 | Minimal — only 2 connections |
+| `Memory` | ~44MB | `(inbound + outbound streams) × 32KB + 32MB base` |
+

--- a/docs/network-limits.md
+++ b/docs/network-limits.md
@@ -7,6 +7,10 @@ This document explains how the libp2p resource manager parameters are calculated
 - **Leader node**: Connected to up to `maxOperators` (default 32) regular nodes
 - **Regular node**: Connected to 1 leader node
 
+## Broadcast Optimization
+
+When broadcasting CVS, COS, or secret values, the leader **skips the originating operator**. The operator who submitted the data already has it locally, so there's no need to send it back to them. This reduces network overhead and stream usage.
+
 ## Stream Protocols
 
 | Direction (relative to leader) | Protocol | Description |
@@ -16,9 +20,34 @@ This document explains how the libp2p resource manager parameters are calculated
 | Inbound | `/cos` | COS submission |
 | Inbound | `/secretValue` | Secret value revelation |
 | Inbound | `/acknowledgment` | Broadcast receipt acknowledgment |
-| Outbound | `/cvsBroadcast` | Broadcast CVS to all operators |
-| Outbound | `/cosBroadcast` | Broadcast COS to all operators |
-| Outbound | `/secretBroadcast` | Broadcast secret to all operators |
+| Outbound | `/cvsBroadcast` | Broadcast CVS to other operators (skip originator) |
+| Outbound | `/cosBroadcast` | Broadcast COS to other operators (skip originator) |
+| Outbound | `/secretBroadcast` | Broadcast secret to other operators (skip originator) |
+| Outbound | `/sendSecretValue` | Request secret reveal from specific operator |
+
+## Memory Constants Explained
+
+The memory calculation uses specific constants based on libp2p's resource consumption patterns:
+
+| Constant | Value | Explanation |
+|---|---|---|
+| `512 * 1024` | 512 KB | Memory per connection. Each TCP/QUIC connection requires buffers for send/receive, connection state, encryption state (TLS/Noise), and multiplexer state. 512KB is a conservative estimate. |
+| `32 * 1024` | 32 KB | Memory per stream. Each multiplexed stream needs read/write buffers and protocol state. Streams are lightweight compared to connections. |
+| `256 * 1024 * 1024` | 256 MB | Base memory overhead for the leader node. Includes libp2p host, DHT (if used), peerstore, connection manager, and application-level data structures. |
+| `32 * 1024 * 1024` | 32 MB | Base memory overhead for regular nodes. Smaller since regular nodes have fewer responsibilities and maintain less state. |
+| `× 4` (FD multiplier) | 4 FDs/conn | Each connection may use multiple file descriptors: the socket itself, potential upgrade connections, and internal pipes for the multiplexer. |
+
+### Memory Formula
+
+**Leader Node:**
+```
+Memory = (connections × 512KB) + (streamsInbound × 32KB) + (streamsOutbound × 32KB) + 256MB base
+```
+
+**Regular Node:**
+```
+Memory = ((streamsInbound + streamsOutbound) × 32KB) + 32MB base
+```
 
 ## Leader Node Calculations
 
@@ -26,52 +55,59 @@ Rounds execute sequentially. Values below are for a single round with `maxOperat
 
 ### Connections
 
-| Parameter | Value | Formula |
-|---|---|---|
-| `ConnsInbound` | 40 | `maxOperators + 25% buffer` |
-| `ConnsOutbound` | 40 | Same as inbound (symmetric) |
+| Parameter | Base Value | With 25% Buffer | Formula |
+|---|---|---|---|
+| `ConnsInbound` | 32 | 40 | `maxOperators + 25%` |
+| `ConnsOutbound` | 32 | 40 | Same as inbound (symmetric) |
 
 ### Streams (per round)
 
-**Inbound = 3200 streams:**
+**Inbound = 3104 streams (base):**
 
 | Source | Count | Calculation |
 |---|---|---|
 | Registration | 32 | 1 per operator |
 | CVS commits | 32 | 1 per operator |
-| CVS acks | 1024 | 32 CVS values × 32 operators acknowledging each |
+| CVS acks | 992 | 32 CVS values × 31 operators acknowledging each (originator skipped) |
 | COS submissions | 32 | 1 per operator |
-| COS acks | 1024 | 32 COS values × 32 operators acknowledging each |
+| COS acks | 992 | 32 COS values × 31 operators acknowledging each |
 | Secret submissions | 32 | 1 per operator |
-| Secret acks | 1024 | 32 secret values × 32 operators acknowledging each |
+| Secret acks | 992 | 32 secret values × 31 operators acknowledging each |
 
-**Outbound = 3072 streams:**
+**Outbound = 2976 streams (base):**
 
 | Source | Count | Calculation |
 |---|---|---|
-| CVS broadcasts | 1024 | 32 CVS values × 32 operators |
-| COS broadcasts | 1024 | 32 COS values × 32 operators |
-| Secret broadcasts | 1024 | 32 secret values × 32 operators |
+| CVS broadcasts | 992 | 32 CVS values × 31 operators (originator skipped) |
+| COS broadcasts | 992 | 32 COS values × 31 operators (originator skipped) |
+| Secret broadcasts | 992 | 32 secret values × 31 operators (originator skipped) |
 
-A **25% safety margin** is applied to both, giving final values of **4000 inbound** and **3840 outbound**.
+A **25% safety margin** is applied, giving final values of **3880 inbound** and **3720 outbound**.
 
 ### Per-Connection Limits
 
-| Parameter | Value | Reasoning |
-|---|---|---|
-| `ConnBaseLimit.StreamsInbound` | 96 | Per regular node: 32 CVS acks + 32 COS acks + 32 Secret acks |
-| `ConnBaseLimit.StreamsOutbound` | 10 | Per regular node: broadcasts + overhead |
+| Parameter | Base Value | With 25% Buffer | Reasoning |
+|---|---|---|---|
+| `ConnBaseLimit.StreamsInbound` | 97 | 121 | 31 CVS acks + 31 COS acks + 31 Secret acks + 4 submissions |
+| `ConnBaseLimit.StreamsOutbound` | 280 | 350 | `3 × 31 × 3 retries + 1` = 280 |
+
+The outbound per-connection limit accounts for:
+- 31 CVS broadcasts (for other operators' CVS values)
+- 31 COS broadcasts (for other operators' COS values)
+- 31 Secret broadcasts (for other operators' secrets)
+- 1 secret value request
+- × 3 retries for reliability
 
 ### File Descriptors and Memory
 
 | Parameter | Value | Formula |
 |---|---|---|
-| `FD` | 160 | `estimatedConnections × 4` (~4 FDs per connection) |
-| `Memory` | ~530MB | `connections × 512KB + streams × 32KB + 256MB base` |
+| `FD` | 160 | `estimatedConnections × 4` (4 FDs per connection for socket + multiplexer) |
+| `Memory` | ~500MB | `(40 × 512KB) + (3880 × 32KB) + (3720 × 32KB) + 256MB` |
 
 ## Regular Node Calculations
 
-A regular node only connects to the leader. It receives broadcasts for all operators and sends acks.
+A regular node only connects to the leader. It receives broadcasts for all **other** operators (not its own) and sends acks.
 
 ### Connections
 
@@ -84,31 +120,60 @@ A regular node only connects to the leader. It receives broadcasts for all opera
 
 The leader retries broadcasts up to **3 times** if no acknowledgment is received.
 
-**Inbound = `3 × maxOperators × 3 retries` = 288 streams:**
+**Inbound = 279 streams (base), 348 with 25% buffer:**
 
 | Source | Count | Calculation |
 |---|---|---|
-| CVS broadcasts | 96 | 32 operators × 3 retries |
-| COS broadcasts | 96 | 32 operators × 3 retries |
-| Secret broadcasts | 96 | 32 operators × 3 retries |
+| CVS broadcasts | 93 | 31 other operators × 3 retries |
+| COS broadcasts | 93 | 31 other operators × 3 retries |
+| Secret broadcasts | 93 | 31 other operators × 3 retries |
 
-**Outbound = `3 + (3 × maxOperators)` = 99 streams:**
+**Outbound = 96 streams (base), 120 with 25% buffer:**
 
 | Source | Count | Calculation |
 |---|---|---|
 | CVS commit | 1 | Own commitment |
 | COS submission | 1 | Own COS |
 | Secret submission | 1 | Own secret |
-| ACKs | 96 | 1 ack per successfully received broadcast (32 operators × 3 phases) |
+| ACKs | 93 | 1 ack per received broadcast (31 other operators × 3 phases) |
 
 ### Per-Connection Limits
 
 Per-connection limits equal system limits since the regular node has only one meaningful connection (to the leader).
 
+| Parameter | Base Value | With 25% Buffer |
+|---|---|---|
+| `StreamsInbound` | 279 | 348 |
+| `StreamsOutbound` | 96 | 120 |
+
 ### File Descriptors and Memory
 
 | Parameter | Value | Formula |
 |---|---|---|
-| `FD` | 32 | Minimal — only 2 connections |
-| `Memory` | ~44MB | `(inbound + outbound streams) × 32KB + 32MB base` |
+| `FD` | 32 | Minimal — only 2 connections × 4 FDs + buffer |
+| `Memory` | ~47MB | `((348 + 120) × 32KB) + 32MB base` |
 
+## Summary
+
+### Broadcast Optimization Impact
+
+The broadcast optimization (skipping originator) reduces:
+- Leader outbound streams: 3072 → 2976 (before safety margin)
+- Leader inbound acks: 3072 → 2976 (before safety margin)
+- Regular node inbound broadcasts: 288 → 279
+- Regular node outbound acks: 96 → 93
+
+This optimization saves ~3% of network overhead while ensuring operators don't receive redundant copies of their own data.
+
+### Final Values Summary
+
+| Node Type | Parameter | Final Value |
+|---|---|---|
+| Leader | System Streams Inbound | 3880 |
+| Leader | System Streams Outbound | 3720 |
+| Leader | Conn Streams Inbound | 121 |
+| Leader | Conn Streams Outbound | 350 |
+| Leader | Memory | ~500MB |
+| Regular | System Streams Inbound | 348 |
+| Regular | System Streams Outbound | 120 |
+| Regular | Memory | ~47MB |

--- a/libp2putils/libp2p_client.go
+++ b/libp2putils/libp2p_client.go
@@ -42,6 +42,55 @@ func (p *P2PClient) GetHostInstance() host.Host {
 	return p.hostInstance
 }
 
+// calculateOptimalLimits calculates resource limits based on node type and expected operator count.
+// See docs/network-limits.md for detailed parameter calculations.
+func calculateOptimalLimits(nodeType string, maxOperators int) rcmgr.ScalingLimitConfig {
+	limits := rcmgr.DefaultLimits
+
+	if nodeType == "leader" {
+		estimatedConnections := maxOperators + (maxOperators / 4)
+
+		streamsInbound := 3200
+		streamsOutbound := 3072
+
+		// 25% safety margin
+		streamsInbound = streamsInbound + (streamsInbound / 4)
+		streamsOutbound = streamsOutbound + (streamsOutbound / 4)
+
+		limits.SystemBaseLimit.ConnsInbound = estimatedConnections
+		limits.SystemBaseLimit.ConnsOutbound = estimatedConnections
+		limits.SystemBaseLimit.StreamsInbound = streamsInbound
+		limits.SystemBaseLimit.StreamsOutbound = streamsOutbound
+		limits.ConnBaseLimit.StreamsInbound = 96
+		limits.ConnBaseLimit.StreamsOutbound = 10
+		limits.SystemBaseLimit.FD = estimatedConnections * 4
+		limits.SystemBaseLimit.Memory = int64((estimatedConnections * 512 * 1024) + (streamsInbound * 32 * 1024) + (streamsOutbound * 32 * 1024) + (256 * 1024 * 1024))
+
+		log.Printf("Leader node limits: %d connections (in/out), %d streams inbound, %d streams outbound (for %d operators)",
+			estimatedConnections, streamsInbound, streamsOutbound, maxOperators)
+
+	} else {
+		limits.SystemBaseLimit.ConnsInbound = 2
+		limits.SystemBaseLimit.ConnsOutbound = 2
+
+		maxRetries := 3
+		streamsInbound := 3 * maxOperators * maxRetries
+		streamsOutbound := 3 + (3 * maxOperators)
+
+		limits.SystemBaseLimit.StreamsInbound = streamsInbound
+		limits.SystemBaseLimit.StreamsOutbound = streamsOutbound
+		limits.ConnBaseLimit.StreamsInbound = streamsInbound
+		limits.ConnBaseLimit.StreamsOutbound = streamsOutbound
+		limits.SystemBaseLimit.FD = 32
+		limits.SystemBaseLimit.Memory = int64(((streamsInbound + streamsOutbound) * 32 * 1024) + (32 * 1024 * 1024))
+
+		log.Printf("Regular node limits: %d connections, %d streams inbound, %d streams outbound (for %d operators)",
+			2, streamsInbound, streamsOutbound, maxOperators)
+	}
+
+	return limits
+}
+
 // CreateHost creates a new libp2p host with a given port and private key.
 func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID, error) {
 	// Load configuration once
@@ -101,20 +150,10 @@ func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID
 		log.Printf("%s validated successfully: %s", envVarName, regularPeerIDFromEnv)
 	}
 
-	limits := rcmgr.DefaultLimits
-	limits.SystemBaseLimit.StreamsInbound = 512
-	limits.SystemBaseLimit.StreamsOutbound = 512
-	limits.SystemBaseLimit.ConnsInbound = 256
-	limits.SystemBaseLimit.ConnsOutbound = 256
-	limits.SystemBaseLimit.FD = 512
+	maxOperators := 32 //
 
-	// per connection per peer limit
-	limits.ConnBaseLimit.StreamsInbound = 64
-	limits.ConnBaseLimit.StreamsOutbound = 64
-
-	limits.SystemBaseLimit.Memory = 1 << 30
-
-	scaledLimits := limits.Scale(256, 512)
+	limits := calculateOptimalLimits(nodeType, maxOperators)
+	scaledLimits := limits.Scale(1, 1)
 
 	rm, err := rcmgr.NewResourceManager(
 		rcmgr.NewFixedLimiter(scaledLimits),
@@ -132,8 +171,12 @@ func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID
 		return nil, "", fmt.Errorf("failed to create libp2p host: %v", err)
 	}
 
-	log.Printf("%s host created with PeerID: %s (Resource limits: %d streams, %d conns)",
-		nodeType, peerID.String(), 512, 256)
+	log.Printf("%s host created with PeerID: %s (Resource limits: %d streams inbound, %d streams outbound, %d conns inbound, %d conns outbound)",
+		nodeType, peerID.String(),
+		limits.SystemBaseLimit.StreamsInbound,
+		limits.SystemBaseLimit.StreamsOutbound,
+		limits.SystemBaseLimit.ConnsInbound,
+		limits.SystemBaseLimit.ConnsOutbound)
 	return h, peerID, nil
 }
 

--- a/libp2putils/libp2p_client.go
+++ b/libp2putils/libp2p_client.go
@@ -50,32 +50,42 @@ func calculateOptimalLimits(nodeType string, maxOperators int) rcmgr.ScalingLimi
 	if nodeType == "leader" {
 		estimatedConnections := maxOperators + (maxOperators / 4)
 
-		streamsInbound := 3200
-		streamsOutbound := 3072
+		streamsInbound := 3104
+		streamsOutbound := 2976
 
 		// 25% safety margin
 		streamsInbound = streamsInbound + (streamsInbound / 4)
 		streamsOutbound = streamsOutbound + (streamsOutbound / 4)
 
+		connStreamsInbound := 97
+		connStreamsOutbound := 280
+		// 25% safety margin for per-connection limits
+		connStreamsInbound = connStreamsInbound + (connStreamsInbound / 4)
+		connStreamsOutbound = connStreamsOutbound + (connStreamsOutbound / 4)
+
 		limits.SystemBaseLimit.ConnsInbound = estimatedConnections
 		limits.SystemBaseLimit.ConnsOutbound = estimatedConnections
 		limits.SystemBaseLimit.StreamsInbound = streamsInbound
 		limits.SystemBaseLimit.StreamsOutbound = streamsOutbound
-		limits.ConnBaseLimit.StreamsInbound = 96
-		limits.ConnBaseLimit.StreamsOutbound = 10
+		limits.ConnBaseLimit.StreamsInbound = connStreamsInbound
+		limits.ConnBaseLimit.StreamsOutbound = connStreamsOutbound
 		limits.SystemBaseLimit.FD = estimatedConnections * 4
 		limits.SystemBaseLimit.Memory = int64((estimatedConnections * 512 * 1024) + (streamsInbound * 32 * 1024) + (streamsOutbound * 32 * 1024) + (256 * 1024 * 1024))
 
-		log.Printf("Leader node limits: %d connections (in/out), %d streams inbound, %d streams outbound (for %d operators)",
-			estimatedConnections, streamsInbound, streamsOutbound, maxOperators)
+		log.Printf("Leader node limits: %d connections (in/out), %d streams inbound, %d streams outbound, conn streams out: %d (for %d operators)",
+			estimatedConnections, streamsInbound, streamsOutbound, connStreamsOutbound, maxOperators)
 
 	} else {
 		limits.SystemBaseLimit.ConnsInbound = 2
 		limits.SystemBaseLimit.ConnsOutbound = 2
 
 		maxRetries := 3
-		streamsInbound := 3 * maxOperators * maxRetries
-		streamsOutbound := 3 + (3 * maxOperators)
+
+		streamsInbound := 3 * (maxOperators - 1) * maxRetries
+		streamsOutbound := 3 + (3 * (maxOperators - 1))
+
+		streamsInbound = streamsInbound + (streamsInbound / 4)
+		streamsOutbound = streamsOutbound + (streamsOutbound / 4)
 
 		limits.SystemBaseLimit.StreamsInbound = streamsInbound
 		limits.SystemBaseLimit.StreamsOutbound = streamsOutbound

--- a/nodes/leader/broad_cast.go
+++ b/nodes/leader/broad_cast.go
@@ -53,7 +53,12 @@ func (n *LeaderNode) ReliableBroadCastSSync(ctx context.Context, h host.Host, ro
 	}
 
 	for _, op := range activatedOps {
-		tracker.Acknowledged[op.Hex()] = false
+		// Mark the originating operator as already acknowledged (they don't need their own data)
+		if op.Hex() == eoaAddress {
+			tracker.Acknowledged[op.Hex()] = true
+		} else {
+			tracker.Acknowledged[op.Hex()] = false
+		}
 	}
 
 	if err := n.broadcastTrackerRepository.AddBroadcastTracker(ctx, tracker); err != nil {
@@ -91,7 +96,12 @@ func (n *LeaderNode) ReliableBroadCastCOS(ctx context.Context, roundNum string, 
 	}
 
 	for _, op := range activatedOps {
-		tracker.Acknowledged[op.Hex()] = false
+		// Mark the originating operator as already acknowledged (they don't need their own data)
+		if op.Hex() == eoaAddress.Hex() {
+			tracker.Acknowledged[op.Hex()] = true
+		} else {
+			tracker.Acknowledged[op.Hex()] = false
+		}
 	}
 
 	if err := n.broadcastTrackerRepository.AddBroadcastTracker(ctx, tracker); err != nil {
@@ -124,7 +134,12 @@ func (n *LeaderNode) ReliableBroadCastCVS(ctx context.Context, roundNum string, 
 	}
 
 	for _, op := range activatedOps {
-		tracker.Acknowledged[op.Hex()] = false
+		// Mark the originating operator as already acknowledged (they don't need their own data)
+		if op.Hex() == eoaAddress.Hex() {
+			tracker.Acknowledged[op.Hex()] = true
+		} else {
+			tracker.Acknowledged[op.Hex()] = false
+		}
 	}
 
 	if err := n.broadcastTrackerRepository.AddBroadcastTracker(ctx, tracker); err != nil {


### PR DESCRIPTION
- Replace hardcoded libp2p resource manager limits with calculated values based on node type (leader vs regular) and expected operator count (32)             
  - Leader nodes get higher connection/stream limits to handle broadcasts and acknowledgments from all operators                                                
  - Regular nodes get minimal limits since they only connect to the leader                                                                                      
  - Add documentation explaining the calculation methodology                                                                                                    
                                                                                                                                                                
  ## Changes                                                                                                                                                    
  - **`libp2putils/libp2p_client.go`**: Add `calculateOptimalLimits()` function that computes connection, stream, FD, and memory limits per node type. Replace  
  previous flat limits (512 streams, 256 conns for all nodes) with role-aware values.                                                                           
  - **`docs/network-limits.md`**: New document detailing stream/connection calculations for each protocol phase (CVS, COS, secret) including retry and          
  acknowledgment overhead.                                                                                    