### PR TITLE
fix: address critical bugs in websocket reconnection and error handling

### DIFF
--- a/nodes/leader/accept_commit.go
+++ b/nodes/leader/accept_commit.go
@@ -350,15 +350,13 @@ func (n *LeaderNode) resuming(ctx context.Context) error {
 
 func (n *LeaderNode) processCOS(ctx context.Context, round *big.Int, trialNum *big.Int, cos [32]byte, activatedOperatorIndex *big.Int) error {
 	if n.GetHalted() {
-		log.Println("System is halted. Skipping processCOS.")
-		return nil
+		return fmt.Errorf("system is halted. Skipping processCOS")
 	}
 	fmt.Printf("Round %v, TrialNum %v, activatedOperatorIndex %v\n", round, trialNum, activatedOperatorIndex)
 
 	activatedOps := n.ethService.GetActivatedOperatorsCached()
 	if activatedOperatorIndex.Int64() >= int64(len(activatedOps)) {
-		log.Printf("Index %d out of bounds for activated operators length %d", activatedOperatorIndex.Int64(), len(activatedOps))
-		return nil
+		return fmt.Errorf("index %d out of bounds for activated operators length %d", activatedOperatorIndex.Int64(), len(activatedOps))
 	}
 	eoa := activatedOps[activatedOperatorIndex.Int64()]
 	cosHex := hex.EncodeToString(cos[:])
@@ -447,16 +445,14 @@ func (n *LeaderNode) updateCOS(ctx context.Context, round string, trialNum strin
 
 func (n *LeaderNode) processCVS(ctx context.Context, round *big.Int, trialNum *big.Int, cvs [32]byte, activatedOperatorIndex *big.Int) error {
 	if n.GetHalted() {
-		log.Println("System is halted. Skipping processCVS.")
-		return nil
+		return fmt.Errorf("system is halted. Skipping processCVS")
 	}
 	fmt.Printf("Round %v, TrialNum %v, activatedOperatorIndex %v\n", round, trialNum, activatedOperatorIndex)
 	roundStr := round.String()
 	trialNumStr := trialNum.String()
 	activatedOps := n.ethService.GetActivatedOperatorsCached()
 	if activatedOperatorIndex.Int64() >= int64(len(activatedOps)) {
-		log.Printf("Index %d out of bounds for activated operators length %d", activatedOperatorIndex.Int64(), len(activatedOps))
-		return nil
+		return fmt.Errorf("index %d out of bounds for activated operators length %d", activatedOperatorIndex.Int64(), len(activatedOps))
 	}
 	eoa := activatedOps[activatedOperatorIndex.Int64()]
 	cvsHex := hex.EncodeToString(cvs[:])
@@ -1402,16 +1398,16 @@ func (n *LeaderNode) getLastProcessedCoords() (uint64, uint, uint) {
 }
 
 func (n *LeaderNode) updateLastProcessedCoords(blockNumber uint64, txIndex uint, logIndex uint) {
-	n.lastProcessedCoordsMu.RLock()
+	n.lastProcessedCoordsMu.Lock()
+	defer n.lastProcessedCoordsMu.Unlock()
+
 	currentBlock := n.lastProcessedBlock
 	currentTxIndex := n.lastProcessedTxIndex
 	currentLogIndex := n.lastProcessedLogIndex
-	n.lastProcessedCoordsMu.RUnlock()
 
-	isNewBlock := blockNumber > currentBlock
 	shouldUpdate := false
 
-	if isNewBlock {
+	if blockNumber > currentBlock {
 		shouldUpdate = true
 	} else if blockNumber == currentBlock {
 		if txIndex > currentTxIndex {
@@ -1424,11 +1420,9 @@ func (n *LeaderNode) updateLastProcessedCoords(blockNumber uint64, txIndex uint,
 	}
 
 	if shouldUpdate {
-		n.lastProcessedCoordsMu.Lock()
 		n.lastProcessedBlock = blockNumber
 		n.lastProcessedTxIndex = txIndex
 		n.lastProcessedLogIndex = logIndex
-		n.lastProcessedCoordsMu.Unlock()
 	}
 }
 
@@ -1666,9 +1660,6 @@ func (n *LeaderNode) processEventLog(ctx context.Context, vLog types.Log, parsed
 
 func (n *LeaderNode) catchUpMissedEvents(ctx context.Context, contractAddr common.Address, parsedABI abi.ABI) error {
 	lastProcessedBlock, _, _ := n.getLastProcessedCoords()
-	if lastProcessedBlock == 0 {
-		return nil
-	}
 
 	currentHeader, err := n.fallbackEthClient.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -1676,6 +1667,15 @@ func (n *LeaderNode) catchUpMissedEvents(ctx context.Context, contractAddr commo
 	}
 
 	currentBlock := currentHeader.Number.Uint64()
+
+	// If this is the first connection (no blocks processed yet), initialize the tracking
+	// to the current block so that subsequent reconnections can catch up properly
+	if lastProcessedBlock == 0 {
+		log.Printf("First connection: initializing lastProcessedBlock to current block %d", currentBlock)
+		n.updateLastProcessedCoords(currentBlock, 0, 0)
+		return nil
+	}
+
 	if currentBlock <= lastProcessedBlock {
 		return nil
 	}
@@ -1684,7 +1684,7 @@ func (n *LeaderNode) catchUpMissedEvents(ctx context.Context, contractAddr commo
 
 	query := ethereum.FilterQuery{
 		Addresses: []common.Address{contractAddr},
-		FromBlock: big.NewInt(int64(lastProcessedBlock)),
+		FromBlock: big.NewInt(int64(lastProcessedBlock + 1)),
 		ToBlock:   big.NewInt(int64(currentBlock)),
 	}
 

--- a/nodes/leader/accept_commit_test.go
+++ b/nodes/leader/accept_commit_test.go
@@ -3373,6 +3373,10 @@ func TestLeaderNode_receiveCommit_StatusEvent_State1(t *testing.T) {
 	}
 	mockSub.On("Unsubscribe").Return()
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3467,6 +3471,10 @@ func TestLeaderNode_receiveCommit_CvSubmitted_Success(t *testing.T) {
 	}
 	node.ethService = mockEth
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3550,6 +3558,10 @@ func TestLeaderNode_receiveCommit_CoSubmitted_Success(t *testing.T) {
 	}
 	node.ethService = mockEth
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3607,6 +3619,10 @@ func TestLeaderNode_receiveCommit_ReorgDetection(t *testing.T) {
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3651,6 +3667,10 @@ func TestLeaderNode_receiveCommit_WebsocketReconnection(t *testing.T) {
 
 	os.Setenv("CONTRACT_ADDRESS", "0x1234567890123456789012345678901234567890")
 	defer os.Unsetenv("CONTRACT_ADDRESS")
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	// First subscription fails with websocket error
 	mockSub1 := &MockSubscription{
@@ -3712,6 +3732,10 @@ func TestLeaderNode_receiveCommit_MerkleRootSubmitted_Success(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3781,6 +3805,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCo_Success(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3854,6 +3882,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCv_Success(t *testing.T) {
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3918,6 +3950,10 @@ func TestLeaderNode_receiveCommit_InvalidEventData(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -4739,6 +4775,10 @@ func TestLeaderNode_receiveCommit_StatusEvent_State2(t *testing.T) {
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -5134,6 +5174,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitSFromIndexK_Success(t *testin
 	node.SetRequestedToSubmitCoMonitoringActive(true)
 	node.requestedToSubmitCoMonitoringTimer = time.AfterFunc(10*time.Second, func() {})
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -5189,6 +5233,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitSFromIndexK_DecodeError(t *te
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5269,6 +5317,10 @@ func TestLeaderNode_receiveCommit_SSubmitted_Success(t *testing.T) {
 	// Set secret request sent for which round
 	node.SetSecretRequestSentForWhichRound("100")
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -5339,6 +5391,10 @@ func TestLeaderNode_receiveCommit_SSubmitted_DecodeError(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5417,6 +5473,10 @@ func TestLeaderNode_receiveCommit_SSubmitted_BlockTimestampError(t *testing.T) {
 	node.ethService = mockEth
 
 	node.SetSecretRequestSentForWhichRound("100")
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5571,6 +5631,10 @@ func TestLeaderNode_receiveCommit_DeActivated_DecodeError(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5806,6 +5870,10 @@ func TestLeaderNode_receiveCommit_MerkleRootSubmitted_BlockTimestampError(t *tes
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -5873,6 +5941,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCo_BlockTimestampError(t *tes
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5943,6 +6015,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCv_BlockTimestampError(t *tes
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -6005,6 +6081,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCo_DecodeError(t *testing.T) 
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -6061,6 +6141,10 @@ func TestLeaderNode_receiveCommit_RequestedToSubmitCv_DecodeError(t *testing.T) 
 		errChan: make(chan error),
 	}
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -6116,6 +6200,10 @@ func TestLeaderNode_receiveCommit_StatusEvent_DecodeError(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -6179,6 +6267,10 @@ func TestLeaderNode_receiveCommit_StatusEvent_BlockTimestampError(t *testing.T) 
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -6255,6 +6347,10 @@ func TestLeaderNode_receiveCommit_StatusEvent_State3(t *testing.T) {
 	mockSub := &MockSubscription{
 		errChan: make(chan error),
 	}
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -8203,7 +8299,7 @@ func TestLeaderNode_updateLastProcessedCoords_ConcurrentUpdates(t *testing.T) {
 	assert.GreaterOrEqual(t, logIndex, uint(0))
 }
 
-// TestLeaderNode_catchUpMissedEvents_InitialState tests when lastProcessedBlock is 0 (should return early)
+// TestLeaderNode_catchUpMissedEvents_InitialState tests when lastProcessedBlock is 0 (should initialize to current block)
 func TestLeaderNode_catchUpMissedEvents_InitialState(t *testing.T) {
 	node := createTestNodeForAcceptCommit()
 	mockClient := new(MockFallbackEthClientForAcceptCommit)
@@ -8214,12 +8310,23 @@ func TestLeaderNode_catchUpMissedEvents_InitialState(t *testing.T) {
 
 	contractAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 
-	// Should return early without calling HeaderByNumber
+	// Mock HeaderByNumber to return current block 200
+	mockHeader := &types.Header{
+		Number: big.NewInt(200),
+	}
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(mockHeader, nil).Once()
+
+	// Should initialize lastProcessedBlock to current block
 	err = node.catchUpMissedEvents(context.Background(), contractAddr, parsedABI)
 	assert.NoError(t, err)
 
-	// Verify HeaderByNumber was not called
-	mockClient.AssertNotCalled(t, "HeaderByNumber", mock.Anything, mock.Anything)
+	// Verify HeaderByNumber was called
+	mockClient.AssertExpectations(t)
+
+	// Verify lastProcessedBlock was initialized
+	lastBlock, _, _ := node.getLastProcessedCoords()
+	assert.Equal(t, uint64(200), lastBlock, "lastProcessedBlock should be initialized to current block")
 }
 
 // TestLeaderNode_catchUpMissedEvents_HeaderByNumberError tests when HeaderByNumber fails
@@ -8293,10 +8400,10 @@ func TestLeaderNode_catchUpMissedEvents_FilterLogsError(t *testing.T) {
 	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
 		Return(mockHeader, nil)
 
-	// Mock FilterLogs to return error
+	// Mock FilterLogs to return error (FromBlock is lastProcessedBlock + 1)
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(nil, errors.New("failed to fetch logs"))
 
 	err = node.catchUpMissedEvents(context.Background(), contractAddr, parsedABI)
@@ -8325,10 +8432,10 @@ func TestLeaderNode_catchUpMissedEvents_NoMissedLogs(t *testing.T) {
 	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
 		Return(mockHeader, nil)
 
-	// Mock FilterLogs to return empty logs
+	// Mock FilterLogs to return empty logs (FromBlock is lastProcessedBlock + 1)
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return([]types.Log{}, nil)
 
 	err = node.catchUpMissedEvents(context.Background(), contractAddr, parsedABI)
@@ -8388,7 +8495,7 @@ func TestLeaderNode_catchUpMissedEvents_SuccessfulCatchUp(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(missedLogs, nil)
 
 	mockClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).
@@ -8461,7 +8568,7 @@ func TestLeaderNode_catchUpMissedEvents_Sorting(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(missedLogs, nil)
 
 	mockClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).
@@ -8553,7 +8660,7 @@ func TestLeaderNode_catchUpMissedEvents_DuplicateDetection(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(missedLogs, nil)
 
 	mockClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).
@@ -8626,7 +8733,7 @@ func TestLeaderNode_catchUpMissedEvents_SortingByTxIndex(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(missedLogs, nil)
 
 	mockClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).
@@ -8699,7 +8806,7 @@ func TestLeaderNode_catchUpMissedEvents_SortingByLogIndex(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 105
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 105
 	})).Return(missedLogs, nil)
 
 	mockClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).
@@ -8971,7 +9078,7 @@ func TestLeaderNode_CatchUpFromSameBlock(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock != nil && q.FromBlock.Uint64() == 100 &&
+			q.FromBlock != nil && q.FromBlock.Uint64() == 101 &&
 			q.ToBlock != nil && q.ToBlock.Uint64() == 101
 	})).Return(missedLogs, nil).Once()
 
@@ -9034,7 +9141,7 @@ func TestLeaderNode_catchUpMissedEvents_OnlyDuplicates_NoUpdate(t *testing.T) {
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock != nil && q.FromBlock.Uint64() == 100 &&
+			q.FromBlock != nil && q.FromBlock.Uint64() == 101 &&
 			q.ToBlock != nil && q.ToBlock.Uint64() == 101
 	})).Return(missedLogs, nil).Once()
 
@@ -9096,7 +9203,7 @@ func TestLeaderNode_catchUpMissedEvents_SameBlockSameTxHigherLogIndex_Processes(
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock != nil && q.FromBlock.Uint64() == 100 &&
+			q.FromBlock != nil && q.FromBlock.Uint64() == 101 &&
 			q.ToBlock != nil && q.ToBlock.Uint64() == 101
 	})).Return(missedLogs, nil).Once()
 
@@ -9145,7 +9252,7 @@ func TestLeaderNode_catchUpMissedEvents_RemovedLog_DoesNotAdvanceCoords(t *testi
 
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock != nil && q.FromBlock.Uint64() == 100 &&
+			q.FromBlock != nil && q.FromBlock.Uint64() == 101 &&
 			q.ToBlock != nil && q.ToBlock.Uint64() == 101
 	})).Return(missedLogs, nil).Once()
 

--- a/nodes/regular/send_commit.go
+++ b/nodes/regular/send_commit.go
@@ -192,8 +192,7 @@ func (n *RegularNode) processSubmittedSecretRequest(ctx context.Context, round, 
 
 func (n *RegularNode) processSecretRequest(ctx context.Context, round, trialNum, index *big.Int) error {
 	if n.GetHalted() {
-		fmt.Println("system is halted. Skipping processSubmittedSecretRequest.")
-		return nil
+		return fmt.Errorf("system is halted. Skipping processSecretRequest")
 	}
 	if appconfig.Get().DisableSecretSubmission {
 		return fmt.Errorf("secret submission is disabled via configuration. Skipping processSecretRequest.")
@@ -279,8 +278,7 @@ func (n *RegularNode) submitS(ctx context.Context, round string, trialNum string
 
 func (n *RegularNode) processMerkleRoot(Round *big.Int, TrialNum *big.Int) error {
 	if n.GetHalted() {
-		log.Println("System is halted. Skipping processSubmittedSecretRequest.")
-		return nil
+		return fmt.Errorf("system is halted. Skipping processMerkleRoot")
 	}
 	fmt.Printf("Round %v, TrialNum %v\n", Round, TrialNum)
 	uniqueKey := utils.GetUniqueKey(Round.String(), TrialNum.String())
@@ -913,16 +911,16 @@ func (n *RegularNode) getLastProcessedCoords() (uint64, uint, uint) {
 }
 
 func (n *RegularNode) updateLastProcessedCoords(blockNumber uint64, txIndex uint, logIndex uint) {
-	n.lastProcessedCoordsMu.RLock()
+	n.lastProcessedCoordsMu.Lock()
+	defer n.lastProcessedCoordsMu.Unlock()
+
 	currentBlock := n.lastProcessedBlock
 	currentTxIndex := n.lastProcessedTxIndex
 	currentLogIndex := n.lastProcessedLogIndex
-	n.lastProcessedCoordsMu.RUnlock()
 
-	isNewBlock := blockNumber > currentBlock
 	shouldUpdate := false
 
-	if isNewBlock {
+	if blockNumber > currentBlock {
 		shouldUpdate = true
 	} else if blockNumber == currentBlock {
 		if txIndex > currentTxIndex {
@@ -935,11 +933,9 @@ func (n *RegularNode) updateLastProcessedCoords(blockNumber uint64, txIndex uint
 	}
 
 	if shouldUpdate {
-		n.lastProcessedCoordsMu.Lock()
 		n.lastProcessedBlock = blockNumber
 		n.lastProcessedTxIndex = txIndex
 		n.lastProcessedLogIndex = logIndex
-		n.lastProcessedCoordsMu.Unlock()
 	}
 }
 
@@ -1018,6 +1014,7 @@ func (n *RegularNode) processEventLog(ctx context.Context, vLog types.Log, parse
 		err = n.processCommitRequest(ctx, eventData.Round, eventData.TrialNum, eventData.PackedIndicesAscendingFromLSB)
 		if err != nil {
 			log.Printf("Failed to process commit request: %v", err)
+			return
 		}
 
 	case StatusSig:
@@ -1106,6 +1103,7 @@ func (n *RegularNode) processEventLog(ctx context.Context, vLog types.Log, parse
 		err = n.processCosRequest(ctx, eventData.Round, eventData.TrialNum, eventData.PackedIndices, eventData.IndicesLength)
 		if err != nil {
 			log.Printf("Failed to process cos request: %v", err)
+			return
 		}
 
 	case RequestedToSubmitSFromIndexKSig:
@@ -1181,9 +1179,6 @@ func (n *RegularNode) processEventLog(ctx context.Context, vLog types.Log, parse
 
 func (n *RegularNode) catchUpMissedEvents(ctx context.Context, contractAddr common.Address, parsedABI abi.ABI) error {
 	lastProcessedBlock, _, _ := n.getLastProcessedCoords()
-	if lastProcessedBlock == 0 {
-		return nil
-	}
 
 	currentHeader, err := n.fallbackEthClient.HeaderByNumber(ctx, nil)
 	if err != nil {
@@ -1191,6 +1186,15 @@ func (n *RegularNode) catchUpMissedEvents(ctx context.Context, contractAddr comm
 	}
 
 	currentBlock := currentHeader.Number.Uint64()
+
+	// If this is the first connection (no blocks processed yet), initialize the tracking
+	// to the current block so that subsequent reconnections can catch up properly
+	if lastProcessedBlock == 0 {
+		log.Printf("First connection: initializing lastProcessedBlock to current block %d", currentBlock)
+		n.updateLastProcessedCoords(currentBlock, 0, 0)
+		return nil
+	}
+
 	if currentBlock <= lastProcessedBlock {
 		return nil
 	}
@@ -1199,7 +1203,7 @@ func (n *RegularNode) catchUpMissedEvents(ctx context.Context, contractAddr comm
 
 	query := ethereum.FilterQuery{
 		Addresses: []common.Address{contractAddr},
-		FromBlock: big.NewInt(int64(lastProcessedBlock)),
+		FromBlock: big.NewInt(int64(lastProcessedBlock + 1)),
 		ToBlock:   big.NewInt(int64(currentBlock)),
 	}
 

--- a/nodes/regular/send_commit_test.go
+++ b/nodes/regular/send_commit_test.go
@@ -2987,6 +2987,10 @@ func TestRegularNode_receiveCommitRequest_MultipleEvents_OneFails_OthersContinue
 	}
 	mockSub.On("Unsubscribe").Return()
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventCount := int32(0)
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3328,6 +3332,10 @@ func TestRegularNode_receiveCommitRequest_ReorgDetection(t *testing.T) {
 	}
 	mockSub.On("Unsubscribe").Return()
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3392,6 +3400,10 @@ func TestRegularNode_receiveCommitRequest_StatusEvent_State1(t *testing.T) {
 		errChan: make(chan error),
 	}
 	mockSub.On("Unsubscribe").Return()
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3471,6 +3483,10 @@ func TestRegularNode_receiveCommitRequest_StatusEvent_InvalidData(t *testing.T) 
 	}
 	mockSub.On("Unsubscribe").Return()
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3538,6 +3554,10 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_Success(t *testing
 		errChan: make(chan error),
 	}
 	mockSub.On("Unsubscribe").Return()
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3610,6 +3630,10 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_DecodeError(t *tes
 	}
 	mockSub.On("Unsubscribe").Return()
 
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
+
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -3667,6 +3691,10 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_BlockTimestampErro
 		errChan: make(chan error),
 	}
 	mockSub.On("Unsubscribe").Return()
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3736,6 +3764,10 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCv_ProcessCommitReque
 		errChan: make(chan error),
 	}
 	mockSub.On("Unsubscribe").Return()
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -3822,6 +3854,10 @@ func TestRegularNode_receiveCommitRequest_RequestedToSubmitCo_ProcessCosRequestE
 		errChan: make(chan error),
 	}
 	mockSub.On("Unsubscribe").Return()
+
+	// Mock HeaderByNumber for catchUpMissedEvents on reconnection (initializes to current block)
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{Number: big.NewInt(1)}, nil).Maybe()
 
 	eventSent := false
 	mockClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
@@ -5753,7 +5789,7 @@ func TestRegularNode_StartMerkleRootMonitoring_LogsElseBranch(t *testing.T) {
 
 // Test cases for catchUpMissedEvents function
 
-func TestRegularNode_catchUpMissedEvents_FirstTime_NoCatchUpNeeded(t *testing.T) {
+func TestRegularNode_catchUpMissedEvents_FirstTime_InitializesTracking(t *testing.T) {
 	node := createTestNodeForSendCommit()
 	mockClient := new(MockFallbackEthClient)
 	node.fallbackEthClient = mockClient
@@ -5762,13 +5798,25 @@ func TestRegularNode_catchUpMissedEvents_FirstTime_NoCatchUpNeeded(t *testing.T)
 	parsedABI, err := utils.LoadContractABI("contract/abi/Commit2RevealDRB.json")
 	require.NoError(t, err)
 
-	// lastProcessedBlock is 0 by default
+	// Mock HeaderByNumber to return current block 200
+	mockHeader := &types.Header{
+		Number: big.NewInt(200),
+	}
+	mockClient.On("HeaderByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(mockHeader, nil).Once()
+
+	// lastProcessedBlock is 0 by default - should initialize to current block
 	err = node.catchUpMissedEvents(context.Background(), contractAddr, parsedABI)
 
 	assert.NoError(t, err)
-	// Verify no calls were made to HeaderByNumber or FilterLogs
-	mockClient.AssertNotCalled(t, "HeaderByNumber")
+	// Verify HeaderByNumber was called
+	mockClient.AssertExpectations(t)
+	// Verify FilterLogs was not called since this is first connection
 	mockClient.AssertNotCalled(t, "FilterLogs")
+
+	// Verify lastProcessedBlock was initialized
+	lastBlock, _, _ := node.getLastProcessedCoords()
+	assert.Equal(t, uint64(200), lastBlock, "lastProcessedBlock should be initialized to current block")
 }
 
 func TestRegularNode_catchUpMissedEvents_NoNewBlocks(t *testing.T) {
@@ -5841,7 +5889,7 @@ func TestRegularNode_catchUpMissedEvents_NoMissedLogs(t *testing.T) {
 	contractAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	mockClient.On("FilterLogs", mock.Anything, mock.MatchedBy(func(q ethereum.FilterQuery) bool {
 		return len(q.Addresses) == 1 && q.Addresses[0] == contractAddr &&
-			q.FromBlock.Uint64() == 100 && q.ToBlock.Uint64() == 150
+			q.FromBlock.Uint64() == 101 && q.ToBlock.Uint64() == 150
 	})).Return([]types.Log{}, nil).Once()
 
 	parsedABI, err := utils.LoadContractABI("contract/abi/Commit2RevealDRB.json")


### PR DESCRIPTION
## Summary

- Fix missing return after `processCosRequest`/`processCommitRequest` errors, preventing events from being marked as processed on failure
- Fix first connection catch-up issue where `lastProcessedBlock == 0` caused catch-up to skip - now initializes to current block
- Fix off-by-one error in FilterLogs range (`FromBlock` should be `lastProcessedBlock + 1` to avoid duplicate processing)
- Fix TOCTOU race condition in `updateLastProcessedCoords` by using single write lock instead of separate read/write locks
- Standardize halted state error handling to return errors consistently instead of silently returning nil
- Fix bounds check in `processCOS`/`processCVS` to return errors instead of nil

## Test plan

- [x] Project builds successfully (`go build ./...`)
- [x] Core unit tests pass for modified functions
- [ ] Run full test suite after integration test mocks are updated
- [ ] Test websocket reconnection scenario manually