### PR TITLE
feat: use public IP in production and local IP while testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,9 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 ```
 
-**Note**: The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section below for detailed instructions.
+**Note**: 
+- The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section below for detailed instructions.
+- **For local/test environment**: The `STATUS` variable is **not required**. The node will automatically use local IP addresses.
 
 #### Configuration by Chain ID
 
@@ -423,6 +425,26 @@ Before deploying nodes, ensure the following:
    docker network create drb-production-net
    ```
 
+3. **Configure Environment Status** (Required for Production):  
+   Set the `STATUS` environment variable in your `.env` file based on your deployment environment:
+   
+   **For Production Deployment (AWS, Cloud Platforms):**
+   ```bash
+   STATUS=prod
+   ```
+   - Nodes will use public IP addresses for communication
+   - Required when nodes are deployed on different networks/VPCs
+   - Required for internet-based communication between nodes
+   
+   **For Local Development:**
+   ```bash
+   # Do NOT set STATUS variable - leave it unset
+   ```
+   - Nodes will automatically use local/Docker network IP addresses
+   - No configuration needed for local testing
+   - Works automatically with Docker Compose networks
+   - **Important**: Do not add `STATUS` variable to your `.env` file for local development
+
 ### Deploying Leader Node
 
 If you want to run a Leader Node on your system, follow these steps:
@@ -447,10 +469,16 @@ CHAIN_ID=<Chain_ID>
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 
+# Environment Status (Required for Production Deployment)
+STATUS=prod
+
 # Contract Period Configuration (based on CHAIN_ID)
 ```
 
-**Note**: The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section for the correct values based on your network.
+**Note**: 
+- The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section for the correct values based on your network.
+- **For production deployment**: Set `STATUS=prod` to use public IP addresses. This is required for nodes deployed on AWS or other cloud platforms where nodes need to communicate over the internet.
+- **For local development**: Do **NOT** set the `STATUS` variable. Leave it unset in your `.env` file. The node will automatically use local/Docker network IP addresses.
 
 #### Leader Node Deployment Steps
 
@@ -511,10 +539,16 @@ CHAIN_ID=<Chain_ID>
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=<Your Production Database Password>
 
+# Environment Status (Required for Production Deployment)
+STATUS=prod
+
 # Contract Period Configuration (based on CHAIN_ID)
 ```
 
-**Note**: The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section for the correct values based on your network.
+**Note**: 
+- The contract period configuration values must be set according to your `CHAIN_ID`. See the [Configuration by Chain ID](#configuration-by-chain-id) section for the correct values based on your network.
+- **For production deployment**: Set `STATUS=prod` to use public IP addresses. This is required for nodes deployed on AWS or other cloud platforms where nodes need to communicate over the internet.
+- **For local development**: Do **NOT** set the `STATUS` variable. Leave it unset in your `.env` file. The node will automatically use local/Docker network IP addresses.
 
 #### Regular Node Deployment Steps
 

--- a/config/env.go
+++ b/config/env.go
@@ -18,6 +18,7 @@ type EnvConfig struct {
 	Port              string
 	RegularNodeNumber string
 	RegularPeerID     string // Regular node peer ID (REGULAR{N}_PEER_ID)
+	Status            string // Environment status (e.g., "prod" for production)
 
 	// Leader connection details for regular nodes
 	LeaderIP     string
@@ -134,6 +135,7 @@ func loadEnv() *EnvConfig {
 		Port:                        os.Getenv("PORT"),
 		RegularNodeNumber:           os.Getenv("REGULAR_NODE_NUMBER"),
 		RegularPeerID:               os.Getenv("REGULAR_PEER_ID"),
+		Status:                      os.Getenv("STATUS"),
 		LeaderIP:                    os.Getenv("LEADER_IP"),
 		LeaderPort:                  os.Getenv("LEADER_PORT"),
 		LeaderPeerID:                os.Getenv("LEADER_PEER_ID"),

--- a/libp2putils/libp2p_client.go
+++ b/libp2putils/libp2p_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 
 	"github.com/libp2p/go-libp2p"
@@ -139,8 +140,12 @@ func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID
 
 // ConnectToPeer connects to a specified peer using its multiaddress.
 func (p *P2PClient) ConnectToPeer(ctx context.Context, leaderIP, leaderPort, leaderPeerID string) (*peer.AddrInfo, error) {
-	// leaderAddrString := fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
-	leaderAddrString := fmt.Sprintf("/dns/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
+	var leaderAddrString string
+	if net.ParseIP(leaderIP) != nil {
+		leaderAddrString = fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
+	} else {
+		leaderAddrString = fmt.Sprintf("/dns/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
+	}
 	log.Printf("Leader multiaddress: %s", leaderAddrString)
 
 	leaderAddr, err := multiaddr.NewMultiaddr(leaderAddrString)

--- a/libp2putils/libp2p_client.go
+++ b/libp2putils/libp2p_client.go
@@ -140,7 +140,7 @@ func (p *P2PClient) CreateHost(port string, nodeType string) (host.Host, peer.ID
 // ConnectToPeer connects to a specified peer using its multiaddress.
 func (p *P2PClient) ConnectToPeer(ctx context.Context, leaderIP, leaderPort, leaderPeerID string) (*peer.AddrInfo, error) {
 	// leaderAddrString := fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
-	leaderAddrString := fmt.Sprintf("/dns/leadernode/tcp/%s/p2p/%s", leaderPort, leaderPeerID)
+	leaderAddrString := fmt.Sprintf("/dns/%s/tcp/%s/p2p/%s", leaderIP, leaderPort, leaderPeerID)
 	log.Printf("Leader multiaddress: %s", leaderAddrString)
 
 	leaderAddr, err := multiaddr.NewMultiaddr(leaderAddrString)

--- a/nodes/leader/registration_helper.go
+++ b/nodes/leader/registration_helper.go
@@ -30,12 +30,8 @@ func (n *LeaderNode) RegisterNode(ctx context.Context, s network.Stream, abiFile
 
 // registerNodeInternal contains the core registration logic to ease unit testing.
 func (n *LeaderNode) registerNodeInternal(ctx context.Context, req utils.RegistrationRequest, remoteAddr string) error {
-	verifyReq := utils.Verification{
-		EOAAddress: req.EOAAddress,
-		Signature:  req.Signature,
-	}
-	if !utils.VerifySignature(verifyReq) {
-		return fmt.Errorf("failed to verify signature for PeerID: %s", req.PeerID)
+	if !utils.VerifyRegistrationRequestContentSignature(req, req.EOAAddress) {
+		return fmt.Errorf("signature verification failed for registration request from EOA: %s. EOAAddress, PeerID, IP, or Port may have been tampered", req.EOAAddress)
 	}
 
 	log.Printf("Verified registration for PeerID: %s", req.PeerID)

--- a/nodes/leader/registration_helper.go
+++ b/nodes/leader/registration_helper.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -63,33 +62,30 @@ func (n *LeaderNode) registerNodeInternal(ctx context.Context, req utils.Registr
 
 	log.Printf("EOA %s is activated, proceeding with registration", req.EOAAddress)
 
-	parts := strings.Split(remoteAddr, "/")
-	if len(parts) < 5 {
-		return fmt.Errorf("invalid remote address format: %s", remoteAddr)
+	// Use IP and Port from registration request (public IP if prod, local IP otherwise)
+	if req.IP == "" || req.Port == "" {
+		return fmt.Errorf("IP or Port not provided in registration request")
 	}
-
-	ip := parts[2]   // Extract IP
-	port := parts[4] // Extract port
 
 	// Update or add the node information
 	nodeInfo := utils.NodeInfo{
-		IP:         ip,
-		Port:       port,
+		IP:         req.IP,
+		Port:       req.Port,
 		PeerID:     req.PeerID,
 		EOAAddress: req.EOAAddress,
 	}
 
 	// Save updated nodes
 	log.Printf("Attempting to register node: EOA=%s, IP=%s, Port=%s, PeerID=%s",
-		req.EOAAddress, ip, port, req.PeerID)
+		req.EOAAddress, req.IP, req.Port, req.PeerID)
 
 	err := n.nodeInfoRepository.AddAndUpdateNodeInfo(ctx, &nodeInfo)
 	if err != nil {
 		log.Printf("Registration failed for EOA %s: %v", req.EOAAddress, err)
-		log.Printf("Registration details: IP=%s, Port=%s, PeerID=%s", ip, port, req.PeerID)
+		log.Printf("Registration details: IP=%s, Port=%s, PeerID=%s", req.IP, req.Port, req.PeerID)
 		return fmt.Errorf("failed to save registered nodes: %v", err)
 	}
 
-	log.Printf("Successfully registered or updated EOA %s with NodeInfo: IP=%s, Port=%s, PeerID=%s.", req.EOAAddress, ip, port, req.PeerID)
+	log.Printf("Successfully registered or updated EOA %s with NodeInfo: IP=%s, Port=%s, PeerID=%s.", req.EOAAddress, req.IP, req.Port, req.PeerID)
 	return nil
 }

--- a/nodes/regular/handler.go
+++ b/nodes/regular/handler.go
@@ -136,11 +136,9 @@ func (rh *RegularNodeHandler) Run(ctx context.Context) {
 	rh.regularNode.SetRegularNodePrivateKey(privateKey)
 	log.Printf("EOA Address: %s", eoaAddress)
 
-	var ip string
-	if envCfg.Status == "prod" {
-		ip = utils.GetPublicIP() // Use public IP for production
-	} else {
-		ip = utils.GetLocalIP() // Use local IP for non-production
+	ip, err := rh.getNodeIP()
+	if err != nil {
+		log.Fatalf("Failed to get IP address: %v", err)
 	}
 
 	// Save the node's information (IP, Port, PeerID, EOA address)
@@ -433,24 +431,37 @@ func (rh *RegularNodeHandler) checkActivationStatus(ctx context.Context, client 
 	return false, false
 }
 
+func (rh *RegularNodeHandler) getNodeIP() (string, error) {
+	envCfg := appconfig.Get()
+	if envCfg.Status == "prod" {
+		return utils.GetPublicIP()
+	}
+	return utils.GetLocalIP()
+}
+
 // sendRegistrationRequestToLeader sends the registration request to the leader node
 func (rh *RegularNodeHandler) sendRegistrationRequestToLeader(ctx context.Context, h core.Host, leaderID peer.ID, eoaAddress string, privateKey *ecdsa.PrivateKey) {
 	envCfg := appconfig.Get()
 
-	var ip string
-	if envCfg.Status == "prod" {
-		ip = utils.GetPublicIP() // Use public IP for production
-	} else {
-		ip = utils.GetLocalIP() // Use local IP for non-production
+	ip, err := rh.getNodeIP()
+	if err != nil {
+		log.Printf("Failed to get IP address: %v", err)
+		return
 	}
 
 	req := utils.RegistrationRequest{
 		EOAAddress: eoaAddress,
-		Signature:  utils.SignData(eoaAddress, privateKey),
 		PeerID:     h.ID().String(),
 		IP:         ip,
 		Port:       envCfg.Port,
 	}
+
+	signature, err := utils.SignRegistrationRequestContent(req, privateKey)
+	if err != nil {
+		log.Printf("Failed to sign registration request: %v", err)
+		return
+	}
+	req.Signature = signature
 
 	stream, err := h.NewStream(ctx, leaderID, "/register")
 	if err != nil {

--- a/nodes/regular/handler.go
+++ b/nodes/regular/handler.go
@@ -136,8 +136,12 @@ func (rh *RegularNodeHandler) Run(ctx context.Context) {
 	rh.regularNode.SetRegularNodePrivateKey(privateKey)
 	log.Printf("EOA Address: %s", eoaAddress)
 
-	// Get the local IP address of the node
-	ip := utils.GetLocalIP() // Use dynamic IP retrieval
+	var ip string
+	if envCfg.Status == "prod" {
+		ip = utils.GetPublicIP() // Use public IP for production
+	} else {
+		ip = utils.GetLocalIP() // Use local IP for non-production
+	}
 
 	// Save the node's information (IP, Port, PeerID, EOA address)
 	nodeInfo := utils.NodeInfo{
@@ -431,10 +435,21 @@ func (rh *RegularNodeHandler) checkActivationStatus(ctx context.Context, client 
 
 // sendRegistrationRequestToLeader sends the registration request to the leader node
 func (rh *RegularNodeHandler) sendRegistrationRequestToLeader(ctx context.Context, h core.Host, leaderID peer.ID, eoaAddress string, privateKey *ecdsa.PrivateKey) {
+	envCfg := appconfig.Get()
+
+	var ip string
+	if envCfg.Status == "prod" {
+		ip = utils.GetPublicIP() // Use public IP for production
+	} else {
+		ip = utils.GetLocalIP() // Use local IP for non-production
+	}
+
 	req := utils.RegistrationRequest{
 		EOAAddress: eoaAddress,
 		Signature:  utils.SignData(eoaAddress, privateKey),
 		PeerID:     h.ID().String(),
+		IP:         ip,
+		Port:       envCfg.Port,
 	}
 
 	stream, err := h.NewStream(ctx, leaderID, "/register")

--- a/utils/ip_retriever.go
+++ b/utils/ip_retriever.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"strings"
+	"time"
 )
 
 // GetLocalIP returns the local IP address of the node
@@ -32,18 +34,22 @@ func GetLocalIP() string {
 
 // GetPublicIP returns the public IP address of the node by querying an external service
 func GetPublicIP() string {
-	resp, err := http.Get("http://checkip.amazonaws.com/")
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get("https://checkip.amazonaws.com/")
 	if err != nil {
 		log.Printf("Failed to get public IP: %v", err)
 		return "0.0.0.0"
 	}
 	defer resp.Body.Close()
 
-	publicIP, err := ioutil.ReadAll(resp.Body)
+	publicIP, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("Failed to read public IP response: %v", err)
 		return "0.0.0.0"
 	}
 
-	return string(publicIP)
+	return strings.TrimSpace(string(publicIP))
 }

--- a/utils/ip_retriever.go
+++ b/utils/ip_retriever.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -9,11 +10,10 @@ import (
 	"time"
 )
 
-// GetLocalIP returns the local IP address of the node
-func GetLocalIP() string {
+func GetLocalIP() (string, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		log.Fatalf("Failed to get network interfaces: %v", err)
+		return "", fmt.Errorf("failed to get network interfaces: %w", err)
 	}
 
 	for _, iface := range interfaces {
@@ -24,32 +24,43 @@ func GetLocalIP() string {
 		}
 		for _, addr := range addrs {
 			if ipNet, ok := addr.(*net.IPNet); ok && !ipNet.IP.IsLoopback() && ipNet.IP.To4() != nil {
-				// Return the first non-loopback IPv4 address
-				return ipNet.IP.String()
+				localIP := ipNet.IP.String()
+				if net.ParseIP(localIP) == nil {
+					continue
+				}
+				return localIP, nil
 			}
 		}
 	}
-	return "0.0.0.0" // Default fallback if no IP found
+	return "", fmt.Errorf("no valid non-loopback IPv4 address found on any network interface")
 }
-
-// GetPublicIP returns the public IP address of the node by querying an external service
-func GetPublicIP() string {
+func GetPublicIP() (string, error) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
 	resp, err := client.Get("https://checkip.amazonaws.com/")
 	if err != nil {
-		log.Printf("Failed to get public IP: %v", err)
-		return "0.0.0.0"
+		return "", fmt.Errorf("failed to get public IP: %w", err)
 	}
 	defer resp.Body.Close()
 
-	publicIP, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("Failed to read public IP response: %v", err)
-		return "0.0.0.0"
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("public IP service returned non-200 status: %d", resp.StatusCode)
 	}
 
-	return strings.TrimSpace(string(publicIP))
+	publicIPBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read public IP response: %w", err)
+	}
+
+	publicIP := strings.TrimSpace(string(publicIPBytes))
+	if publicIP == "" {
+		return "", fmt.Errorf("public IP service returned empty response")
+	}
+	if net.ParseIP(publicIP) == nil {
+		return "", fmt.Errorf("public IP service returned invalid IP address: %q", publicIP)
+	}
+
+	return publicIP, nil
 }

--- a/utils/ip_retriever_test.go
+++ b/utils/ip_retriever_test.go
@@ -10,66 +10,46 @@ import (
 )
 
 func TestGetLocalIP(t *testing.T) {
-	localIP := GetLocalIP()
-	
+	localIP, err := GetLocalIP()
+
+	if err != nil {
+		t.Skipf("GetLocalIP failed (may be expected in some environments): %v", err)
+		return
+	}
+
 	// Verify it returns a valid IP format
+	assert.NoError(t, err)
 	assert.NotEmpty(t, localIP)
-	
+
 	// Parse the IP to verify it's valid
 	parsedIP := net.ParseIP(localIP)
 	assert.NotNil(t, parsedIP, "Returned IP should be in valid format")
-	
-	// Should not be loopback
-	if localIP != "0.0.0.0" { // 0.0.0.0 is fallback when no IP found
-		assert.False(t, parsedIP.IsLoopback(), "Should not return loopback IP")
-	}
-	
+	assert.False(t, parsedIP.IsLoopback(), "Should not return loopback IP")
+
 	// Should be IPv4
 	ipv4 := parsedIP.To4()
 	assert.NotNil(t, ipv4, "Should return IPv4 address")
 }
 
 func TestGetPublicIP(t *testing.T) {
-	t.Run("successful API call", func(t *testing.T) {
-		// Create a mock server that returns a fake public IP
-		expectedIP := "203.0.113.1"
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(expectedIP))
-		}))
-		defer server.Close()
-
-		// Temporarily replace the AWS IP service URL with our test server
-		// Since GetPublicIP() hardcodes the URL, we need to test with a wrapper
-		// For now, let's test the actual function which should return a valid IP or 0.0.0.0
-		publicIP := GetPublicIP()
-		
-		// Verify it returns a valid IP format
-		assert.NotEmpty(t, publicIP)
-		
-		// Trim any whitespace (AWS service returns with newline)
-		publicIP = publicIP[:len(publicIP)-1]
-		
-		// Parse the IP to verify it's valid
-		parsedIP := net.ParseIP(publicIP)
-		assert.NotNil(t, parsedIP, "Returned IP should be in valid format")
-	})
-
 	t.Run("integration test with actual service", func(t *testing.T) {
 		// This is an integration test that calls the actual AWS service
 		// It might fail in environments without internet access
-		publicIP := GetPublicIP()
-		
+		publicIP, err := GetPublicIP()
+
+		if err != nil {
+			// Skip test if service is unavailable (e.g., no internet)
+			t.Skipf("Public IP service unavailable: %v", err)
+			return
+		}
+
+		assert.NoError(t, err)
 		assert.NotEmpty(t, publicIP)
-		
-		// Trim whitespace from the result (AWS returns IP with newline)
-		publicIP = publicIP[:len(publicIP)-1] // Remove trailing newline
-		
+
 		// Parse the IP to verify it's valid
 		parsedIP := net.ParseIP(publicIP)
-		if publicIP != "0.0.0.0" { // Only validate if not fallback
-			assert.NotNil(t, parsedIP, "Returned IP should be in valid format")
-		}
+		assert.NotNil(t, parsedIP, "Returned IP should be in valid format")
+		assert.NotNil(t, parsedIP.To4(), "Should return IPv4 address")
 	})
 }
 
@@ -140,54 +120,33 @@ func TestGetPublicIPWithMockServer(t *testing.T) {
 
 func TestGetLocalIPAdditionalCoverage(t *testing.T) {
 	t.Run("valid IP returned", func(t *testing.T) {
-		ip := GetLocalIP()
-		
-		// Should return either a valid IP or the fallback
-		assert.NotEmpty(t, ip)
-		
-		if ip != "0.0.0.0" {
-			parsedIP := net.ParseIP(ip)
-			assert.NotNil(t, parsedIP)
+		ip, err := GetLocalIP()
+
+		if err != nil {
+			t.Skipf("GetLocalIP failed (may be expected in some environments): %v", err)
+			return
 		}
+
+		// Should return a valid IP
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ip)
+
+		parsedIP := net.ParseIP(ip)
+		assert.NotNil(t, parsedIP, "Returned IP should be valid")
+		assert.NotNil(t, parsedIP.To4(), "Should return IPv4 address")
+		assert.False(t, parsedIP.IsLoopback(), "Should not return loopback IP")
 	})
 }
 
 func TestGetPublicIPErrorPathsAdditional(t *testing.T) {
-	t.Run("HTTP error response simulation", func(t *testing.T) {
-		// Create a server that returns an error status
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("Internal Server Error"))
-		}))
-		defer server.Close()
+	t.Run("invalid IP response", func(t *testing.T) {
+		// Test that GetPublicIP validates the response is a valid IP
+		// We can't easily mock the hardcoded URL, but we can test the validation logic
+		invalidIPs := []string{"not-an-ip", "256.256.256.256", "invalid", ""}
 
-		// We can't directly test GetPublicIP with our server since it uses a hardcoded URL
-		// But we can test the error handling behavior by simulating it
-		
-		resp, err := http.Get(server.URL)
-		if err == nil {
-			defer resp.Body.Close()
-			// This simulates what GetPublicIP does when it gets a non-200 status
-			assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		}
-	})
-
-	t.Run("read error simulation", func(t *testing.T) {
-		// Create a server that closes connection immediately
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Close connection without sending response
-			conn, _, _ := w.(http.Hijacker).Hijack()
-			conn.Close()
-		}))
-		defer server.Close()
-
-		// Test what happens when reading fails
-		resp, err := http.Get(server.URL)
-		if err != nil {
-			// This covers the error path in GetPublicIP
-			assert.Error(t, err)
-		} else if resp != nil {
-			resp.Body.Close()
+		for _, invalidIP := range invalidIPs {
+			parsedIP := net.ParseIP(invalidIP)
+			assert.Nil(t, parsedIP, "Invalid IP should not parse: %q", invalidIP)
 		}
 	})
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,8 @@ type RegistrationRequest struct {
 	EOAAddress string `json:"eoa_address"`
 	Signature  []byte `json:"signature"`
 	PeerID     string `json:"peer_id"`
+	IP         string `json:"ip"`
+	Port       string `json:"port"`
 }
 
 type Verification struct {
@@ -219,7 +221,6 @@ func SignCosRequestContent(req CosRequest, privateKey *ecdsa.PrivateKey) ([]byte
 	}
 	return signature, nil
 }
-
 
 func VerifyCosRequestContentSignature(req CosRequest, expectedSignerEOA string) bool {
 	messageHash := crypto.Keccak256Hash(

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -420,3 +420,40 @@ func VerifyCommitRequestContentSignature(req CommitRequest, expectedSignerEOA st
 
 	return recoveredAddress == expectedAddress
 }
+
+func SignRegistrationRequestContent(req RegistrationRequest, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	messageHash := crypto.Keccak256Hash(
+		[]byte(req.EOAAddress),
+		[]byte(req.PeerID),
+		[]byte(req.IP),
+		[]byte(req.Port),
+	)
+
+	signature, err := crypto.Sign(messageHash.Bytes(), privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign registration request content: %v", err)
+	}
+	return signature, nil
+}
+
+func VerifyRegistrationRequestContentSignature(req RegistrationRequest, expectedSignerEOA string) bool {
+	messageHash := crypto.Keccak256Hash(
+		[]byte(req.EOAAddress),
+		[]byte(req.PeerID),
+		[]byte(req.IP),
+		[]byte(req.Port),
+	)
+
+	pubKey, err := crypto.SigToPub(messageHash.Bytes(), req.Signature)
+	if err != nil {
+		log.Printf("Error recovering public key from registration request signature: %v", err)
+		return false
+	}
+
+	recoveredAddress := crypto.PubkeyToAddress(*pubKey).Hex()
+	expectedAddress := common.HexToAddress(expectedSignerEOA).Hex()
+
+	log.Printf("Registration request signature verification - Recovered: %s, Expected: %s", recoveredAddress, expectedAddress)
+
+	return recoveredAddress == expectedAddress
+}


### PR DESCRIPTION
Summary

  - Add STATUS environment variable to control IP address mode (production vs local)
  - Regular nodes now send their IP and port in registration requests instead of leader parsing from remote address
  - Update libp2p client to use dynamic LEADER_IP for DNS resolution
  - Improve GetPublicIP function with timeout and HTTPS